### PR TITLE
[FIX]In current flow regardless if the product passed or not the last…

### DIFF
--- a/ddmrp_production_equivalent/README.rst
+++ b/ddmrp_production_equivalent/README.rst
@@ -14,20 +14,22 @@ This module uses an equivalent part if the part on the BOM is not available..
 
 Usage
 =====
+
 * Using DDMRP mechanism, If the main part on the BOM is not available (netflow position is in the red or yellow zone) 
   and equivalences can be used, use the first part (based on priority) that have a netflow position in the green zone.
 
 * As an example, when a manufacturing order is created:
-  if Part A from the BOM is available (quantity on hand > requested quantity):
-     use Part A
-  Otherwise
-      If equivalences can be used:
-          Get all the other parts in the same product category
-          Exclude the non-equivalent parts listed in the BOM line
-          Sort the remaining parts by their priority
-          Use the first one
-      Otherwise:
-          Use Part A
+
+If Part A from the BOM is available (quantity on hand > requested quantity):
+  use Part A
+Otherwise
+  If equivalences can be used:
+    Get all the other parts in the same product category
+    Exclude the non-equivalent parts listed in the BOM line
+    Sort the remaining parts by their priority
+    Use the first one
+  Otherwise:
+    Use Part A
 
 Bug Tracker
 ===========

--- a/ddmrp_production_equivalent/__manifest__.py
+++ b/ddmrp_production_equivalent/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "MRP BoM Equivalences when Production Order is Created",
     "summary": "Use equivalences of a part when appropriate",
-    "version": "11.0.1.0.1",
+    "version": "11.0.1.0.2",
     "license": "AGPL-3",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",
     "category": "MRP",

--- a/ddmrp_production_equivalent/models/mrp_production.py
+++ b/ddmrp_production_equivalent/models/mrp_production.py
@@ -18,13 +18,14 @@ class MrpProduction(models.Model):
         # exclude the non-equivalent parts listed in the BOM line and the
         # current product
         products -= bom_line.nonequivalent_product_ids + bom_line.product_id
-        product = False
+        product_eq = False
         for product in products:
             if product.orderpoint_ids and \
                product.orderpoint_ids[0].planning_priority_level == '3_green':
                     if product.qty_available > requested_qty:
+                        product_eq = product
                         break
-        return product
+        return product_eq
 
     def _generate_raw_move(self, bom_line, line_data):
         sm = super(MrpProduction, self)._generate_raw_move(bom_line, line_data)


### PR DESCRIPTION
… product from the list is return as the product equivalent.

Correct return product value to False instead of the last product value from the list in case no products passed the given condition.