### PR TITLE
[11.0][FIX] ddmrp: call _quantity_in_progress with sudo()

### DIFF
--- a/ddmrp/models/stock_warehouse_orderpoint.py
+++ b/ddmrp/models/stock_warehouse_orderpoint.py
@@ -141,7 +141,7 @@ class StockWarehouseOrderpoint(models.Model):
                  "qty_multiple", "product_uom", "procure_uom_id",
                  "product_uom.rounding")
     def _compute_procure_recommended_qty(self):
-        subtract_qty = self._quantity_in_progress()
+        subtract_qty = self.sudo()._quantity_in_progress()
         for rec in self:
             procure_recommended_qty = 0.0
             if rec.net_flow_position < rec.top_of_yellow:


### PR DESCRIPTION
call _quantity_in_progress with sudo() to avoid ACL errors as is an internal ddmrp engine function.

Error use case:
On instances that use call for tender and/or blanket order management, manufacture users could not use procurement request through stock_orderpoint_manual_procurement due to this.