### PR TITLE
[11.0] ddmrp: performance improvements.

### DIFF
--- a/ddmrp/models/mrp_production.py
+++ b/ddmrp/models/mrp_production.py
@@ -47,10 +47,13 @@ class MrpProduction(models.Model):
             rec.execution_priority_level = \
                 rec.orderpoint_id.execution_priority_level
             rec.on_hand_percent = rec.orderpoint_id.on_hand_percent
-        (self - prods).write({
-            'execution_priority_level': None,
-            'on_hand_percent': None,
-        })
+        to_update = (self - prods).filtered(
+            lambda r: r.execution_priority_level or r.on_hand_percent)
+        if to_update:
+            to_update.write({
+                'execution_priority_level': None,
+                'on_hand_percent': None,
+            })
 
     def _search_execution_priority(self, operator, value):
         """Search on the execution priority by evaluating on all

--- a/ddmrp_exclude_moves_adu_calc/models/stock_move.py
+++ b/ddmrp_exclude_moves_adu_calc/models/stock_move.py
@@ -13,6 +13,7 @@ class StockMove(models.Model):
         string='Exclude this move from ADU calculation', copy=False,
         help="If this flag is set this stock move will be excluded from ADU "
              "calculation",
+        index=True,
     )
 
     @api.multi


### PR DESCRIPTION
* When the number of MOs associated to a buffer start to grow the calculation of the priority start to be a bottleneck. With this fix it is solved.
* indexing `exclude_from_adu` the ADU calculation gets faster.