### PR TITLE
[13.0][IMP] ddmrp_packaging: add package_multiple field.

### DIFF
--- a/ddmrp_packaging/views/stock_buffer_view.xml
+++ b/ddmrp_packaging/views/stock_buffer_view.xml
@@ -8,9 +8,10 @@
         <field name="model">stock.buffer</field>
         <field name="inherit_id" ref="ddmrp.stock_buffer_view_form" />
         <field name="arch" type="xml">
-            <group name="other" position="inside">
+            <field name="qty_multiple" position="before">
                 <field name="packaging_id" />
-            </group>
+                <field name="package_multiple" />
+            </field>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23449160/87432446-4b062580-c5e8-11ea-942b-c77181d4898f.png)

a couple of onchange methods keep qty multiple and package multiple aligned.

@ForgeFlow