### PR TITLE
stock_buffer_route: Allow selecting buy/manufacture routes in buffers

### DIFF
--- a/stock_buffer_route/models/stock_buffer.py
+++ b/stock_buffer_route/models/stock_buffer.py
@@ -38,8 +38,14 @@ class StockBuffer(models.Model):
             lambda route: any(
                 p.location_id in parents
                 for p in route.rule_ids.filtered(
-                    lambda rule: rule.action in ("pull", "pull_push")
+                    lambda rule: rule.action in ("pull", "pull_push", "manufacture")
                 ).mapped("location_src_id")
+            )
+            or any(rule.action == "buy" for rule in route.rule_ids)
+            or any(
+                rule.action == "manufacture"
+                for rule in route.rule_ids
+                if not rule.location_src_id
             )
         )
 


### PR DESCRIPTION
Only the last commit is relevant. It's added on top of the migration of the module in #52, but I didn't want to include it as part of the migration.

Previously, only pull, pull/push rules with a source location equal or
child of the buffer's location could be selected.

Extend the the selection of routes to include:

* Buy routes (they have no source location)
* Manufacture routes with a source location equal or child of the
  buffer's location
* Manufacture routes without source location