### PR TITLE
[13.0][IMP] ddmrp: add option to auto procure buffers.

### DIFF
--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -269,6 +269,31 @@ class TestDdmrpCommon(common.SavepointCase):
             }
         )
 
+    def create_picking_out(self, product, date_move, qty):
+        return self.pickingModel.with_user(self.user).create(
+            {
+                "picking_type_id": self.ref("stock.picking_type_out"),
+                "location_id": self.binA.id,
+                "location_dest_id": self.customer_location.id,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Test move",
+                            "product_id": product.id,
+                            "date_expected": date_move,
+                            "date": date_move,
+                            "product_uom": product.uom_id.id,
+                            "product_uom_qty": qty,
+                            "location_id": self.binA.id,
+                            "location_dest_id": self.customer_location.id,
+                        },
+                    )
+                ],
+            }
+        )
+
     def _do_picking(self, picking, date):
         """Do picking with only one move on the given date."""
         picking.action_confirm()

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -185,6 +185,11 @@
                             <field name="procure_min_qty" />
                             <field name="procure_max_qty" />
                             <field name="lead_days" />
+                            <field name="auto_procure" />
+                            <field
+                                name="auto_procure_option"
+                                attrs="{'invisible': [('auto_procure', '=', False)]}"
+                            />
                         </group>
                         <group name="buffer_zones_summary" string="Buffer zones">
                             <field name="top_of_green" />


### PR DESCRIPTION
Whenever the buffer is recomputed, if this option is set, it will procure automatically if needed. There are two options to use this feature: standard (when NFP goes below green) or stockout (when NFP goes below 0).

@ForgeFlow