### PR TITLE
[13.0][ddmrp] use split_every in buffer crons in order to allow more frequent commits

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -3,6 +3,7 @@
 
 import logging
 import operator as py_operator
+import threading
 from collections import defaultdict
 from datetime import datetime, timedelta
 from math import pi
@@ -1195,6 +1196,7 @@ class StockBuffer(models.Model):
     @api.model
     def cron_ddmrp_adu(self, automatic=False):
         """calculate ADU for each DDMRP buffer. Called by cronjob."""
+        auto_commit = not getattr(threading.currentThread(), "testing", False)
         _logger.info("Start cron_ddmrp_adu.")
         buffer_ids = self.search([]).ids
         i = 0
@@ -1209,6 +1211,8 @@ class StockBuffer(models.Model):
                             b._calc_adu()
                     else:
                         b._calc_adu()
+                    if auto_commit:
+                        self._cr.commit()
                 except Exception:
                     _logger.exception("Fail to compute ADU for buffer %s", b.name)
                     if not automatic:
@@ -1238,6 +1242,7 @@ class StockBuffer(models.Model):
     def cron_ddmrp(self, automatic=False):
         """Calculate key DDMRP parameters for each buffer.
         Called by cronjob."""
+        auto_commit = not getattr(threading.currentThread(), "testing", False)
         _logger.info("Start cron_ddmrp.")
         buffer_ids = self.search([]).ids
 
@@ -1255,6 +1260,8 @@ class StockBuffer(models.Model):
                     else:
                         b.refresh()
                         b.cron_actions()
+                    if auto_commit:
+                        self._cr.commit()
                 except Exception:
                     _logger.exception("Fail updating buffer %s", b.name)
                     if not automatic:

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -10,6 +10,7 @@ from math import pi
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools import float_compare, float_round
+from odoo.tools.misc import split_every
 
 _logger = logging.getLogger(__name__)
 try:
@@ -1195,22 +1196,23 @@ class StockBuffer(models.Model):
     def cron_ddmrp_adu(self, automatic=False):
         """calculate ADU for each DDMRP buffer. Called by cronjob."""
         _logger.info("Start cron_ddmrp_adu.")
-        buffers = self.search([])
+        buffer_ids = self.search([]).ids
         i = 0
-        j = len(buffers)
-        for b in buffers:
-            try:
-                i += 1
-                _logger.debug("ddmrp cron_adu: {}. ({}/{})".format(b.name, i, j))
-                if automatic:
-                    with self.env.cr.savepoint():
+        j = len(buffer_ids)
+        for buffer_chunk_ids in split_every(50, buffer_ids):
+            for b in self.browse(buffer_chunk_ids):
+                try:
+                    i += 1
+                    _logger.debug("ddmrp cron_adu: {}. ({}/{})".format(b.name, i, j))
+                    if automatic:
+                        with self.env.cr.savepoint():
+                            b._calc_adu()
+                    else:
                         b._calc_adu()
-                else:
-                    b._calc_adu()
-            except Exception:
-                _logger.exception("Fail to compute ADU for buffer %s", b.name)
-                if not automatic:
-                    raise
+                except Exception:
+                    _logger.exception("Fail to compute ADU for buffer %s", b.name)
+                    if not automatic:
+                        raise
         _logger.info("End cron_ddmrp_adu.")
         return True
 
@@ -1237,22 +1239,25 @@ class StockBuffer(models.Model):
         """Calculate key DDMRP parameters for each buffer.
         Called by cronjob."""
         _logger.info("Start cron_ddmrp.")
-        buffers = self.search([])
+        buffer_ids = self.search([]).ids
+
         i = 0
-        j = len(buffers)
-        buffers.refresh()
-        for b in buffers:
-            i += 1
-            _logger.debug("ddmrp cron: {}. ({}/{})".format(b.name, i, j))
-            try:
-                if automatic:
-                    with self.env.cr.savepoint():
+        j = len(buffer_ids)
+        for buffer_chunk_ids in split_every(50, buffer_ids):
+            for b in self.browse(buffer_chunk_ids):
+                i += 1
+                _logger.debug("ddmrp cron: {}. ({}/{})".format(b.name, i, j))
+                try:
+                    if automatic:
+                        with self.env.cr.savepoint():
+                            b.refresh()
+                            b.cron_actions()
+                    else:
+                        b.refresh()
                         b.cron_actions()
-                else:
-                    b.cron_actions()
-            except Exception:
-                _logger.exception("Fail updating buffer %s", b.name)
-                if not automatic:
-                    raise
+                except Exception:
+                    _logger.exception("Fail updating buffer %s", b.name)
+                    if not automatic:
+                        raise
         _logger.info("End cron_ddmrp.")
         return True


### PR DESCRIPTION
...and locking the buffers for too long.

cc @LoisRForgeFlow 