### PR TITLE
[13.0][FIX] ddmrp: error when adding a purchase order line

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -150,7 +150,7 @@ class StockBuffer(models.Model):
     def _quantity_in_progress(self):
         """Return Quantities that are not yet in virtual stock but should
         be deduced from buffers (example: purchases created from buffers)"""
-        res = dict(self.mapped(lambda x: (x.id, 0.0)))
+        res = {}.fromkeys(self.ids, 0.0)
         polines = self.env["purchase.order.line"].search(
             [
                 ("state", "in", ("draft", "sent", "to approve")),
@@ -505,14 +505,20 @@ class StockBuffer(models.Model):
     def _compute_procure_recommended_qty(self):
         subtract_qty = self.sudo()._quantity_in_progress()
         for rec in self:
+
             procure_recommended_qty = 0.0
-            if rec.net_flow_position < rec.top_of_yellow:
-                qty = rec.top_of_green - rec.net_flow_position - subtract_qty[rec.id]
+            # uses _origin because onchange uses a NewId with the record wrapped
+            if rec._origin and rec.net_flow_position < rec.top_of_yellow:
+                qty = (
+                    rec.top_of_green
+                    - rec.net_flow_position
+                    - subtract_qty[rec._origin.id]
+                )
                 if qty >= 0.0:
                     procure_recommended_qty = qty
-            else:
-                if subtract_qty[rec.id] > 0.0:
-                    procure_recommended_qty -= subtract_qty[rec.id]
+            elif rec._origin:
+                if subtract_qty[rec._origin.id] > 0.0:
+                    procure_recommended_qty -= subtract_qty[rec._origin.id]
 
             adjusted_qty = 0.0
             if procure_recommended_qty > 0.0:


### PR DESCRIPTION
To reproduce:

* Open a Purchase Order with at least one line created by a DDMRP buffer
* Add a new line

When selecting the product, we'll get:

```
    File "/odoo/src/odoo/api.py", line 374, in _call_kw_multi
      result = method(recs, *args, **kwargs)
    File "/odoo/src/odoo/models.py", line 6074, in onchange
      snapshot0.fetch(name)

    [...redacted...]

    File "/odoo/src/odoo/models.py", line 3919, in _compute_field_value
      getattr(self, field.compute)()
    File "/odoo/external-src/ddmrp/stock_buffer_capacity_limit/models/stock_buffer.py", line 20, in _compute_procure_recommended_qty
      res = super()._compute_procure_recommended_qty()
    File "/odoo/external-src/ddmrp/ddmrp/models/stock_buffer.py", line 432, in _compute_procure_recommended_qty
      subtract_qty = self.sudo()._quantity_in_progress()
    File "/odoo/external-src/ddmrp/ddmrp/models/stock_buffer.py", line 157, in _quantity_in_progress
      res[buffer.id] += poline.product_uom._compute_quantity(
    KeyError: 3
```

The problem is that, in this context, the field is computed by an
onchange, which wraps the records with a NewID record. The original
record is stored in "_origin".

The idiom:

```
  {}.fromkeys(self.ids, 0.0)
```

Will automatically unwrap the ids, so we prevent comparing a "<NewID
origin=1>" with the actual ID, which is therefore not found.

In _compute_procure_recommended_qty, use _origin if available or skip
the computation.