### PR TITLE
[13.0][FIX] ddmrp_packaging: ensure regular form view is used + remove check_moq method

### DIFF
--- a/ddmrp_packaging/models/stock_buffer.py
+++ b/ddmrp_packaging/models/stock_buffer.py
@@ -24,7 +24,6 @@ class StockBuffer(models.Model):
             # Check is Ok, we can change package multiple to keep alignment:
             if self.packaging_id.qty:
                 self.package_multiple = self.qty_multiple / self.packaging_id.qty
-                self._check_moq()
         return res
 
     @api.onchange("package_multiple")
@@ -32,11 +31,6 @@ class StockBuffer(models.Model):
         for rec in self:
             if rec.packaging_id.qty:
                 rec.qty_multiple = rec.package_multiple * rec.packaging_id.qty
-                rec._check_moq()
-
-    def _check_moq(self):
-        if self.minimum_order_quantity < self.qty_multiple:
-            self.minimum_order_quantity = self.qty_multiple
 
     def _check_package(self):
         pack = self.packaging_id

--- a/ddmrp_packaging/views/stock_buffer_view.xml
+++ b/ddmrp_packaging/views/stock_buffer_view.xml
@@ -9,7 +9,10 @@
         <field name="inherit_id" ref="ddmrp.stock_buffer_view_form" />
         <field name="arch" type="xml">
             <field name="qty_multiple" position="before">
-                <field name="packaging_id" />
+                <field
+                    name="packaging_id"
+                    context="{'form_view_ref':'product.product_packaging_form_view'}"
+                />
                 <field name="package_multiple" />
             </field>
         </field>


### PR DESCRIPTION
1st commit
========

when navigating to a package from the buffer. For instance, when
the `delivery` module the delivery view gets precedence.

Before:
![Screenshot from 2020-09-02 13-40-21](https://user-images.githubusercontent.com/23449160/91977005-3e699800-ed22-11ea-9fc3-0ca01c797906.png)

After:
![Screenshot from 2020-09-02 13-40-36](https://user-images.githubusercontent.com/23449160/91977017-4295b580-ed22-11ea-8e97-1f21a336eb6a.png)

2nd commit
=========
It has been problem to be a problem more than an aid.
As long as the qty_multiple is updated correctly the recommended
procurement will respect it. MOQ field should be reserved to
contractual constraints agreed with the vendor.

@ForgeFlow