### PR TITLE
[13.0] Add ddmrp_cron_actions_as_job

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1493,6 +1493,18 @@ class StockBuffer(models.Model):
         """This method is meant to be inherited by other modules in order to
         enhance extensibility."""
         self.ensure_one()
+        self.invalidate_cache(
+            fnames=[
+                "product_location_qty",
+                "incoming_location_qty",
+                "outgoing_location_qty",
+                "virtual_location_qty",
+                "product_location_qty_available_not_res",
+                "dlt",
+                "distributed_source_location_qty",
+            ],
+            ids=self.ids,
+        )
         if not only_nfp or only_nfp == "out":
             self._calc_qualified_demand()
         if not only_nfp or only_nfp == "in":

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -12,6 +12,16 @@ class TestDdmrpCommon(common.SavepointCase):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                tracking_disable=True,
+                # compatibility with ddmrp_cron_actions_as_job,
+                # that would delay calls to "cron_actions" in these tests
+                test_queue_job_no_delay=True,
+            )
+        )
+
         # Models
         cls.productModel = cls.env["product.product"]
         cls.templateModel = cls.env["product.template"]

--- a/ddmrp_cron_actions_as_job/__init__.py
+++ b/ddmrp_cron_actions_as_job/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ddmrp_cron_actions_as_job/__manifest__.py
+++ b/ddmrp_cron_actions_as_job/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "DDMRP Buffer Calculation as job",
+    "version": "13.0.1.0.0",
+    "summary": "Run DDMRP Buffer Calculation as jobs",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/ddmrp",
+    "category": "Warehouse Management",
+    "depends": ["ddmrp", "queue_job"],
+    "data": ["data/queue_job_channel_data.xml", "data/queue_job_function_data.xml"],
+    "license": "LGPL-3",
+    "installable": True,
+}

--- a/ddmrp_cron_actions_as_job/data/queue_job_channel_data.xml
+++ b/ddmrp_cron_actions_as_job/data/queue_job_channel_data.xml
@@ -1,0 +1,6 @@
+<odoo noupdate="1">
+    <record model="queue.job.channel" id="channel_ddmrp">
+        <field name="name">ddmrp</field>
+        <field name="parent_id" ref="queue_job.channel_root" />
+    </record>
+</odoo>

--- a/ddmrp_cron_actions_as_job/data/queue_job_function_data.xml
+++ b/ddmrp_cron_actions_as_job/data/queue_job_function_data.xml
@@ -1,0 +1,7 @@
+<odoo noupdate="1">
+    <record id="job_function_stock_buffer_cron_actions" model="queue.job.function">
+        <field name="model_id" ref="ddmrp.model_stock_buffer" />
+        <field name="method">cron_actions</field>
+        <field name="channel_id" ref="channel_ddmrp" />
+    </record>
+</odoo>

--- a/ddmrp_cron_actions_as_job/models/__init__.py
+++ b/ddmrp_cron_actions_as_job/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_buffer
+from . import stock_move

--- a/ddmrp_cron_actions_as_job/models/stock_buffer.py
+++ b/ddmrp_cron_actions_as_job/models/stock_buffer.py
@@ -1,0 +1,51 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models
+
+from odoo.addons.queue_job.job import identity_exact
+
+
+class Buffer(models.Model):
+    _inherit = "stock.buffer"
+
+    def cron_actions_job_options(self, only_nfp=False):
+        return {
+            "identity_key": identity_exact,
+            "priority": 15,
+            "description": "DDMRP Buffer calculation ({})".format(self.display_name),
+        }
+
+    def _calc_adu_job_options(self):
+        return {
+            "identity_key": identity_exact,
+            "priority": 15,
+            "description": "DDMRP Buffer ADU calculation ({})".format(
+                self.display_name
+            ),
+        }
+
+    def _register_hook(self):
+        self._patch_method(
+            "cron_actions",
+            self._patch_job_auto_delay(
+                "cron_actions", context_key="auto_delay_ddmrp_cron_actions"
+            ),
+        )
+        self._patch_method(
+            "_calc_adu",
+            self._patch_job_auto_delay(
+                "_calc_adu", context_key="auto_delay_ddmrp_calc_adu"
+            ),
+        )
+        return super()._register_hook()
+
+    def cron_ddmrp(self, automatic=False):
+        return super(
+            Buffer, self.with_context(auto_delay_ddmrp_cron_actions=True)
+        ).cron_ddmrp(automatic=automatic)
+
+    def cron_ddmrp_adu(self, automatic=False):
+        return super(
+            Buffer, self.with_context(auto_delay_ddmrp_calc_adu=True)
+        ).cron_ddmrp_adu(automatic=automatic)

--- a/ddmrp_cron_actions_as_job/models/stock_move.py
+++ b/ddmrp_cron_actions_as_job/models/stock_move.py
@@ -1,0 +1,13 @@
+# Copyright 2020 Camptocamp
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _update_ddmrp_nfp(self):
+        return super(
+            StockMove, self.with_context(auto_delay_ddmrp_cron_actions=True)
+        )._update_ddmrp_nfp()

--- a/ddmrp_cron_actions_as_job/readme/CONTRIBUTORS.rst
+++ b/ddmrp_cron_actions_as_job/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/ddmrp_cron_actions_as_job/readme/DESCRIPTION.rst
+++ b/ddmrp_cron_actions_as_job/readme/DESCRIPTION.rst
@@ -1,0 +1,14 @@
+DDMRP Buffer calculations are now run with Queue Jobs.
+
+When auto-update of NFP is active, each time the state of a stock move changes,
+a new computation is triggered, but thanks to identity keys on jobs, only one
+job at a time is generated for the same buffer.
+
+The ``<stock.buffer>.cron_actions`` method is automatically delayed when the
+context contains ``auto_delay_ddmrp_cron_actions=True``.
+
+The scheduled action for buffers ADU computation also generates jobs instead
+of recomputing all the buffers at once.
+
+The ``<stock.buffer>._calc_adu`` method is automatically delayed when the
+context contains ``auto_delay_ddmrp_calc_adu=True``.

--- a/ddmrp_cron_actions_as_job/tests/__init__.py
+++ b/ddmrp_cron_actions_as_job/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_cron_actions_as_job

--- a/ddmrp_cron_actions_as_job/tests/test_cron_actions_as_job.py
+++ b/ddmrp_cron_actions_as_job/tests/test_cron_actions_as_job.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+
+from odoo.tests import tagged
+
+from odoo.addons.ddmrp.tests.common import TestDdmrpCommon
+from odoo.addons.queue_job.job import identity_exact
+from odoo.addons.queue_job.tests.common import mock_with_delay
+
+
+@tagged("post_install", "-at_install")
+class TestDdmrpCronActionsAsJob(TestDdmrpCommon):
+    def test_cron_actions_delay_job(self):
+        context = dict(self.env.context, auto_delay_ddmrp_cron_actions=True)
+        del context["test_queue_job_no_delay"]
+        buffer_a = self.buffer_a.with_context(context)
+
+        with mock_with_delay() as (delayable_cls, delayable):
+            buffer_a.cron_actions(only_nfp=True)
+
+            # check 'with_delay()' part:
+            self.assertEqual(delayable_cls.call_count, 1)
+            # arguments passed in 'with_delay()'
+            delay_args, delay_kwargs = delayable_cls.call_args
+            self.assertEqual(delay_args, (self.buffer_a,))
+            self.assertEqual(delay_kwargs.get("priority"), 15)
+            self.assertEqual(delay_kwargs.get("identity_key"), identity_exact)
+
+            # check what's passed to the job method 'cron_actions'
+            self.assertEqual(delayable.cron_actions.call_count, 1)
+            delay_args, delay_kwargs = delayable.cron_actions.call_args
+            self.assertEqual(delay_args, ())
+            self.assertDictEqual(delay_kwargs, {"only_nfp": True})
+
+    def test_calc_adu_delay_job(self):
+        context = dict(self.env.context, auto_delay_ddmrp_calc_adu=True)
+        del context["test_queue_job_no_delay"]
+        buffer_a = self.buffer_a.with_context(context)
+
+        with mock_with_delay() as (delayable_cls, delayable):
+            buffer_a._calc_adu()
+
+            # check 'with_delay()' part:
+            self.assertEqual(delayable_cls.call_count, 1)
+            # arguments passed in 'with_delay()'
+            delay_args, delay_kwargs = delayable_cls.call_args
+            self.assertEqual(delay_args, (self.buffer_a,))
+            self.assertEqual(delay_kwargs.get("priority"), 15)
+            self.assertEqual(delay_kwargs.get("identity_key"), identity_exact)
+
+            # check what's passed to the job method '_calc_adu'
+            self.assertEqual(delayable._calc_adu.call_count, 1)
+            delay_args, delay_kwargs = delayable._calc_adu.call_args
+            self.assertEqual(delay_args, ())
+            self.assertDictEqual(delay_kwargs, {})

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -2,3 +2,4 @@ stock-logistics-warehouse
 web
 manufacture
 server-tools
+queue

--- a/setup/ddmrp_cron_actions_as_job/odoo/addons/ddmrp_cron_actions_as_job
+++ b/setup/ddmrp_cron_actions_as_job/odoo/addons/ddmrp_cron_actions_as_job
@@ -1,0 +1,1 @@
+../../../../ddmrp_cron_actions_as_job

--- a/setup/ddmrp_cron_actions_as_job/setup.py
+++ b/setup/ddmrp_cron_actions_as_job/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
It makes every calls to "cron_actions" run in queue jobs.

The jobs have an identity key with "identity_exact", meaning that only
one occurence of a job for the same buffer with the same arguments
(only_nfp) will be created at a time (e.g. when the state of a
stock.move is changed several times in the same transaction or in
a different transaction in a short timeframe).

It needs https://github.com/OCA/queue/pull/274 and https://github.com/OCA/queue/pull/275