### PR TITLE
[13.0][FIX] ddmrp: do not consider internal reservations.

### DIFF
--- a/ddmrp/__manifest__.py
+++ b/ddmrp/__manifest__.py
@@ -15,7 +15,6 @@
     "depends": [
         "purchase_stock",
         "mrp_bom_location",
-        "stock_available_unreserved",
         "stock_demand_estimate",
         "web_widget_bokeh_chart",
         "mrp_multi_level",

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -222,6 +222,7 @@
                                     class="oe_inline"
                                 /> %
                             </div>
+                            <field name="product_location_qty_available_not_res" />
                             <field name="incoming_dlt_qty" />
                             <field name="qualified_demand" />
                         </group>


### PR DESCRIPTION
Operations done from locations within the buffer area/location should not affect the on hand position of the buffer.

With this change, we rely on `stock.move.line`'s to compute the qty reserved instead of using the `reserved_quantity` on the quant, which is the most accurate way to get the reserved qty. This also eliminates `stock_available_unreserved` dependency.

cc @jbaudoux

@ForgeFlow