### PR TITLE
[13.0] [IMP] Add imposed demand lead time to buffers.

### DIFF
--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -864,6 +864,11 @@ class TestDdmrp(TestDdmrpCommon):
         # Fall back to no-variant supplier info
         self.assertEqual(self.buffer_c_orange.dlt, 8)
 
+    def test_36_dlt_extra_lead_time(self):
+        # Add extra lead time
+        self.buffer_c_blue.extra_lead_time = 20
+        self.assertEqual(self.buffer_c_blue.dlt, 25)
+
     def test_40_bokeh_charts(self):
         """Check bokeh chart computation."""
         date_move = datetime.today()

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -162,6 +162,10 @@
                                 name="red_override"
                                 attrs="{'invisible': [('replenish_method', '!=', 'replenish_override')]}"
                             />
+                            <label for="extra_lead_time" />
+                            <div name="extra_lead_time">
+                                <field name="extra_lead_time" class="oe_inline" /> days
+                            </div>
                             <label for="dlt" />
                             <div name="dlt">
                                 <field name="dlt" class="oe_inline" /> days


### PR DESCRIPTION
When defined, the yellow zone will be computed as the ADU x Imposed Demand Lead Time, if the Imposed Demand Lead
Time is larger than the Replenishment Lead Time. This is particularily useful in situations of infrequent but
periodic demand. E.g. We receive a large order every 30 days, whereas the supplier takes 10 days to supply.

In this case the yellow zone must cover for the entire cycle of 30 days of demand.

In situations with infrequent demand the ADU tends to be very small, and every new order would be treated
as a spike, when in reality this is not an exceptional situation.

![image](https://user-images.githubusercontent.com/7683926/99522985-b39a5000-2996-11eb-99b0-82ec6446ee8e.png)
