### PR TITLE
[13.0][ddmrp][IMP] create decimal precision 'Average Daily Usage'.

### DIFF
--- a/ddmrp/data/decimal_precision_data.xml
+++ b/ddmrp/data/decimal_precision_data.xml
@@ -8,4 +8,12 @@
         <field name="name">Lead Time</field>
         <field name="digits" eval="0" />
     </record>
+    <record
+        forcecreate="True"
+        id="average_daily_usage_decimal_precision"
+        model="decimal.precision"
+    >
+        <field name="name">Average Daily Usage</field>
+        <field name="digits" eval="3" />
+    </record>
 </odoo>

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -765,7 +765,7 @@ class StockBuffer(models.Model):
     adu = fields.Float(
         string="ADU",
         default=0.0,
-        digits="Product Unit of Measure",
+        digits="Average Daily Usage",
         readonly=True,
         help="Average Daily Usage",
     )


### PR DESCRIPTION
Before the decimal precision assigned to the ADU was the Product Unit of Measure, but sometimes this precision can be set
to no digits, which would drive to an incorrect ADU calculation.

![image](https://user-images.githubusercontent.com/7683926/99523701-b6e20b80-2997-11eb-8a1e-b4fd96d407b4.png)
