### PR TITLE
[13.0][IMP] ddmrp: archive buffers when archiving products.

### DIFF
--- a/ddmrp/models/product_product.py
+++ b/ddmrp/models/product_product.py
@@ -10,3 +10,17 @@ class Product(models.Model):
     buffer_ids = fields.One2many(
         comodel_name="stock.buffer", string="Stock Buffers", inverse_name="product_id",
     )
+
+    def write(self, values):
+        res = super().write(values)
+        if "active" in values:
+            buffers = self.env["stock.buffer"].search(
+                [
+                    ("product_id", "in", self.ids),
+                    "|",
+                    ("active", "=", True),
+                    ("active", "=", False),
+                ]
+            )
+            buffers.write({"active": values.get("active")})
+        return res

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -873,3 +873,28 @@ class TestDdmrp(TestDdmrpCommon):
         self.assertTrue(self.buffer_a.ddmrp_chart)
         self.assertTrue(self.buffer_a.ddmrp_demand_chart)
         self.assertTrue(self.buffer_a.ddmrp_supply_chart)
+
+    def test_41_archive_template(self):
+        # archive a product template:
+        self.template_c.toggle_active()
+        self.assertFalse(self.template_c.active)
+        self.assertFalse(self.product_c_blue.active)
+        self.assertFalse(self.product_c_orange.active)
+        self.assertFalse(self.buffer_c_blue.active)
+        self.assertFalse(self.buffer_c_orange.active)
+
+    def test_42_archive_variant(self):
+        # archive a variant
+        self.product_c_blue.toggle_active()
+        self.assertTrue(self.template_c.active)
+        self.assertFalse(self.product_c_blue.active)
+        self.assertTrue(self.product_c_orange.active)
+        self.assertFalse(self.buffer_c_blue.active)
+        self.assertTrue(self.buffer_c_orange.active)
+        # toggle a buffer before toggling product:
+        self.buffer_c_blue.toggle_active()
+        self.assertTrue(self.buffer_c_blue.active)
+        self.assertFalse(self.product_c_blue.active)
+        self.product_c_blue.toggle_active()
+        self.assertTrue(self.buffer_c_blue.active)
+        self.assertTrue(self.product_c_blue.active)


### PR DESCRIPTION
It is clear that when you archive a product you have to archive as well all related buffers, it isn't that clear when you are unarchiving, for now if there is no better proposal we're going to unarchive all buffers as well.

@ForgeFlow