### PR TITLE
[13.0] Add option to limit replenishment to free quantity 

### DIFF
--- a/ddmrp/models/stock_buffer_profile.py
+++ b/ddmrp/models/stock_buffer_profile.py
@@ -55,3 +55,10 @@ class StockBufferProfile(models.Model):
         comodel_name="stock.buffer.profile.variability", string="Variability Factor"
     )
     company_id = fields.Many2one("res.company", "Company",)
+
+    replenish_distributed_limit_to_free_qty = fields.Boolean(
+        string="Limit replenishment to free quantity",
+        default=False,
+        help="When activated, the recommended quantity will be maxed at "
+        "the quantity available in the replenishment source location.",
+    )

--- a/ddmrp/tests/__init__.py
+++ b/ddmrp/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_ddmrp
+from . import test_ddmrp_distributed_source_location

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -43,6 +43,9 @@ class TestDdmrpCommon(common.SavepointCase):
         cls.buffer_profile_mmm = cls.env.ref(
             "ddmrp.stock_buffer_profile_replenish_manufactured_medium_medium"
         )
+        cls.buffer_profile_distr = cls.env.ref(
+            "ddmrp.stock_buffer_profile_replenish_distributed_medium_medium"
+        )
         cls.adu_fixed = cls.env.ref("ddmrp.adu_calculation_method_fixed")
         cls.group_stock_manager = cls.env.ref("stock.group_stock_manager")
         cls.group_mrp_user = cls.env.ref("mrp.group_mrp_user")
@@ -388,7 +391,7 @@ class TestDdmrpCommon(common.SavepointCase):
         for move in picking.move_lines:
             move.date = date
 
-    def create_orderpoint_procurement(self, buffer):
+    def create_orderpoint_procurement(self, buffer, make_procurement=True):
         """Make Procurement from Reordering Rule"""
         context = {
             "active_model": "stock.buffer",
@@ -400,5 +403,6 @@ class TestDdmrpCommon(common.SavepointCase):
             .with_context(context)
             .create({})
         )
-        wizard.make_procurement()
+        if make_procurement:
+            wizard.make_procurement()
         return wizard

--- a/ddmrp/tests/test_ddmrp_distributed_source_location.py
+++ b/ddmrp/tests/test_ddmrp_distributed_source_location.py
@@ -1,0 +1,180 @@
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from .common import TestDdmrpCommon
+
+
+class TestDdmrpDistributedSourceLocation(TestDdmrpCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # we store goods in "Replenish" and make pull rules to
+        # go through "Replenish Step" when we replenish Stock
+        cls.replenish_location = cls.env["stock.location"].create(
+            {
+                "name": "Replenish",
+                "location_id": cls.warehouse.view_location_id.id,
+                "usage": "internal",
+                "company_id": cls.main_company.id,
+            }
+        )
+        replenish_step_location = cls.env["stock.location"].create(
+            {
+                "name": "Replenish Step",
+                "location_id": cls.warehouse.view_location_id.id,
+                "usage": "internal",
+                "company_id": cls.main_company.id,
+            }
+        )
+
+        replenish_route = cls.env["stock.location.route"].create(
+            {"name": "Replenish", "sequence": 1}
+        )
+        cls.env["stock.rule"].create(
+            {
+                "name": "Replenish",
+                "route_id": replenish_route.id,
+                "location_src_id": cls.replenish_location.id,
+                "location_id": replenish_step_location.id,
+                "action": "pull",
+                "picking_type_id": cls.warehouse.int_type_id.id,
+                "procure_method": "make_to_stock",
+                "warehouse_id": cls.warehouse.id,
+                "company_id": cls.main_company.id,
+            }
+        )
+        cls.env["stock.rule"].create(
+            {
+                "name": "Replenish Step",
+                "route_id": replenish_route.id,
+                "location_src_id": replenish_step_location.id,
+                "location_id": cls.warehouse.lot_stock_id.id,
+                "action": "pull",
+                "picking_type_id": cls.warehouse.int_type_id.id,
+                "procure_method": "make_to_order",
+                "warehouse_id": cls.warehouse.id,
+                "company_id": cls.main_company.id,
+            }
+        )
+
+        # our product uses the replenishment route
+        cls.product_c_orange.route_ids = replenish_route
+
+        cls.buffer_dist = cls.bufferModel.create(
+            {
+                "buffer_profile_id": cls.buffer_profile_distr.id,
+                "product_id": cls.product_c_orange.id,
+                "location_id": cls.stock_location.id,
+                "warehouse_id": cls.warehouse.id,
+                "qty_multiple": 1.0,
+                "adu_calculation_method": cls.adu_fixed.id,
+                "adu_fixed": 5.0,
+            }
+        )
+
+        cls.buffer_profile_distr.replenish_distributed_limit_to_free_qty = True
+
+    def test_distributed_source_location_id(self):
+        # as we have a route to replenish from this location, we expect the
+        # buffer to have this location set as source
+        self.assertEqual(
+            self.buffer_dist.distributed_source_location_id, self.replenish_location
+        )
+        self.assertEqual(self.buffer_dist.distributed_source_location_qty, 0)
+
+    def test_distributed_source_location_qty(self):
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_c_orange, self.replenish_location, 4000
+        )
+
+        self.buffer_dist.invalidate_cache()
+        self.assertEqual(self.buffer_dist.distributed_source_location_qty, 4000)
+
+        self.env["stock.quant"]._update_reserved_quantity(
+            self.product_c_orange, self.replenish_location, 500
+        )
+
+        self.buffer_dist.invalidate_cache()
+        self.assertEqual(self.buffer_dist.distributed_source_location_qty, 3500)
+
+        self.assertEqual(
+            self.env["stock.buffer"].search(
+                [("distributed_source_location_qty", "=", 3500)]
+            ),
+            self.buffer_dist,
+        )
+
+    def _set_qty_and_create_replenish_wizard(
+        self, qty_in_replenish=4000, recommended_qty=10000
+    ):
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_c_orange, self.replenish_location, 4000
+        )
+        # lie about the recommended qty (we only want to test if the limit is
+        # applied)
+        self.buffer_dist.procure_recommended_qty = 10000
+
+        return self.create_orderpoint_procurement(
+            self.buffer_dist, make_procurement=False
+        )
+
+    def test_distributed_source_limit_replenish(self):
+        wizard = self._set_qty_and_create_replenish_wizard()
+        self.assertRecordValues(
+            wizard.item_ids,
+            [
+                {
+                    "recommended_qty": 10000,
+                    # limited to the free qty
+                    "qty": 4000,
+                }
+            ],
+        )
+
+    def test_distributed_source_limit_replenish_with_batch_limit_max(self):
+        self.buffer_dist.procure_max_qty = 1200
+        wizard = self._set_qty_and_create_replenish_wizard()
+        self.assertRecordValues(
+            wizard.item_ids,
+            # we expect lines to be per batch of 1200 but maxed to the free qty
+            [
+                {"recommended_qty": 10000, "qty": 1200},
+                {"recommended_qty": 10000, "qty": 1200},
+                {"recommended_qty": 10000, "qty": 1200},
+                {"recommended_qty": 10000, "qty": 400},
+            ],
+        )
+
+    def test_distributed_source_limit_replenish_with_batch_limit_min(self):
+        self.buffer_dist.procure_min_qty = 5000
+        wizard = self._set_qty_and_create_replenish_wizard()
+        self.assertRecordValues(
+            wizard.item_ids,
+            # the 4000 in stock is below the min of 5000, nothing moved
+            [{"recommended_qty": 10000, "qty": 0}],
+        )
+
+    def test_distributed_source_limit_replenish_with_batch_limit_min_and_max(self):
+        self.buffer_dist.procure_min_qty = 1000
+        self.buffer_dist.procure_max_qty = 1200
+        wizard = self._set_qty_and_create_replenish_wizard()
+        self.assertRecordValues(
+            wizard.item_ids,
+            # the last batch would be 400 which is below the min limit,
+            # ignore the remaining
+            [
+                {"recommended_qty": 10000, "qty": 1200},
+                {"recommended_qty": 10000, "qty": 1200},
+                {"recommended_qty": 10000, "qty": 1200},
+            ],
+        )
+
+    def test_distributed_source_limit_disabled(self):
+        self.buffer_profile_distr.replenish_distributed_limit_to_free_qty = False
+        wizard = self._set_qty_and_create_replenish_wizard()
+        self.assertRecordValues(
+            wizard.item_ids,
+            # normal behavior, apply the recommended qty when the option is set
+            # to False on the profile
+            [{"recommended_qty": 10000, "qty": 10000}],
+        )

--- a/ddmrp/views/stock_buffer_profile_view.xml
+++ b/ddmrp/views/stock_buffer_profile_view.xml
@@ -29,6 +29,12 @@
                                 options="{'no_create': True}"
                             />
                         </group>
+                        <group
+                            name="distributed_options"
+                            attrs="{'invisible': [('item_type', '!=', 'distributed')]}"
+                        >
+                            <field name="replenish_distributed_limit_to_free_qty" />
+                        </group>
                     </group>
                 </sheet>
             </form>

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -71,6 +71,15 @@
                     type="object"
                     attrs="{'invisible':[('incoming_outside_dlt_qty', '=', 0), ('rfq_outside_dlt_qty', '=', 0)]}"
                 />
+                <button
+                    string="No stock available on source location for distributed buffer"
+                    name="action_dummy"
+                    icon="fa-warning"
+                    type="object"
+                    attrs="{'invisible':['|', ('distributed_source_location_id', '=', False), ('distributed_source_location_qty', '>', 0)]}"
+                />
+                <field name="distributed_source_location_id" optional="hide" />
+                <field name="distributed_source_location_qty" optional="hide" />
                 <field name="item_type" optional="show" />
                 <field name="main_supplier_id" optional="show" />
                 <field name="adu" />
@@ -232,6 +241,14 @@
                         </group>
                         <group name="misc_info" string="Other Information">
                             <field name="main_supplier_id" />
+                            <field
+                                name="distributed_source_location_id"
+                                attrs="{'invisible': ['|', ('item_type', '!=', 'distributed'), ('distributed_source_location_id', '=', False)]}"
+                            />
+                            <field
+                                name="distributed_source_location_qty"
+                                attrs="{'invisible': ['|', ('item_type', '!=', 'distributed'), ('distributed_source_location_id', '=', False)]}"
+                            />
                         </group>
                     </group>
                     <notebook>
@@ -368,6 +385,12 @@
                     name="has_long_term_supply"
                     string="Has Long Term Supply"
                     domain="['|', ('incoming_outside_dlt_qty', '>', 0), ('rfq_outside_dlt_qty', '>', 0)]"
+                />
+                <separator />
+                <filter
+                    name="has_distributed_source_location_qty"
+                    string="Has Stock In Source Location"
+                    domain="[('distributed_source_location_qty', '>', 0)]"
                 />
                 <separator />
                 <filter

--- a/ddmrp/wizards/make_procurement_buffer_view.xml
+++ b/ddmrp/wizards/make_procurement_buffer_view.xml
@@ -12,6 +12,11 @@
                     this may trigger a draft purchase order, a manufacturing
                     order or a transfer picking.
                 </p>
+                <p class="oe_gray">
+                    By default, the qty is equal to the recommended quantity.
+                    For distributed buffers, when the option on the profile is active,
+                    the quantity is limited to the free quantity.
+                </p>
                 <group>
                     <field
                         name="partner_id"
@@ -32,6 +37,7 @@
                                 groups="stock.group_stock_multi_locations"
                             />
                             <field name="product_id" />
+                            <field name="recommended_qty" />
                             <field name="qty" />
                             <field name="qty_without_security" invisible="1" />
                             <field name="uom_id" groups="uom.group_uom" />

--- a/ddmrp_history/models/ddmrp_history.py
+++ b/ddmrp_history/models/ddmrp_history.py
@@ -9,7 +9,7 @@ class DdmrpHistory(models.Model):
     _description = "DDMRP History"
 
     buffer_id = fields.Many2one(
-        comodel_name="stock.buffer", string="Buffer", ondelete="cascade",
+        comodel_name="stock.buffer", string="Buffer", ondelete="cascade", index=True,
     )
     date = fields.Datetime(string="Date",)
     top_of_red = fields.Float(string="TOR", help="Top of Red", group_operator="avg",)

--- a/stock_buffer_route/models/stock_buffer.py
+++ b/stock_buffer_route/models/stock_buffer.py
@@ -58,3 +58,15 @@ class StockBuffer(models.Model):
         res = super()._prepare_procurement_values(product_qty, date=date, group=group)
         res["route_ids"] = self.route_id
         return res
+
+    def _values_source_location_from_route(self):
+        values = super()._values_source_location_from_route()
+        if self.route_id:
+            values["route_ids"] = self.route_id
+        return values
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "route_id" in vals:
+            self._calc_distributed_source_location()
+        return res


### PR DESCRIPTION
This new feature targets buffers of type 'distributed'.

* Store the source location where the replenishment of a buffer should
  occur.
* The source location is taken from the default first route, so we
  assume the default route is a replenishment, otherwise the computation
  is skipped.
* When `stock_buffer_route` is installed, the route configured on the
  buffer is used to find the replenishment source location.
* A computed field shows the free quantity in the replenishment source
  location.
* When a buffer has no quantity in the replenishment source location, a
  new warning is displayed in the tree view.
* A new option on the buffer profile limits the quantity that can be
  replenished in the procurement wizard to the actual free quantity in
  the replenishment source location. The quantity we can procure for
  this profile will be min(recommended quantity, free quantity).

This is a huge win to avoid backorders for transfers created for
replenishments: we create transfers only for the quantity we have, and
if we do not have this quantity in practice, it reveals a stock issue.