### PR TITLE
[13.0] Add reschedule procurement on distributed buffers

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -226,7 +226,10 @@ class StockBuffer(models.Model):
         self.ensure_one()
         profile = self.buffer_profile_id
         dlt = int(self.dlt)
-        max_proc_time = profile.distributed_reschedule_max_proc_time
+        if profile.item_type == "distributed":
+            max_proc_time = profile.distributed_reschedule_max_proc_time
+        else:
+            max_proc_time = 0
         # For purchased items we always consider calendar days,
         # not work days.
         if profile.item_type == "purchased":

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -224,17 +224,35 @@ class StockBuffer(models.Model):
 
     def _get_date_planned(self):
         self.ensure_one()
+        profile = self.buffer_profile_id
         dlt = int(self.dlt)
+        max_proc_time = profile.distributed_reschedule_max_proc_time
         # For purchased items we always consider calendar days,
         # not work days.
-        if (
-            self.warehouse_id.calendar_id
-            and self.buffer_profile_id.item_type != "purchased"
-        ):
-            dt_planned = self.warehouse_id.wh_plan_days(datetime.now(), dlt)
+        if profile.item_type == "purchased":
+            dt_planned = fields.datetime.today() + timedelta(days=dlt)
         else:
-            dt_planned = fields.date.today() + timedelta(days=dlt)
-        return fields.Date.to_date(dt_planned)
+            if self.warehouse_id.calendar_id:
+                dt_planned = self.warehouse_id.wh_plan_days(fields.datetime.now(), dlt)
+                if max_proc_time:
+                    calendar = self.warehouse_id.calendar_id
+                    # We found the day with "wh_plan_day", now determine
+                    # the first available hour in the day (wh_plan_day returns
+                    # the stop hour), and add the procurement time.
+                    dt_planned = calendar.plan_hours(
+                        # expect hours
+                        max_proc_time / 60,
+                        # start from the first working hours available
+                        dt_planned.replace(hour=0, minute=0, second=0),
+                    )
+
+            else:
+                dt_planned = (
+                    fields.datetime.now()
+                    + timedelta(days=dlt)
+                    + timedelta(minutes=max_proc_time)
+                )
+        return dt_planned
 
     procure_recommended_qty = fields.Float(
         string="Procure Recommendation",

--- a/ddmrp/models/stock_buffer_profile.py
+++ b/ddmrp/models/stock_buffer_profile.py
@@ -28,17 +28,19 @@ class StockBufferProfile(models.Model):
         "variability_id",
         "variability_id.name",
         "variability_id.factor",
+        "distributed_reschedule_max_proc_time",
     )
     def _compute_name(self):
         """Get the right summary for this job."""
         for rec in self:
-            rec.name = "{} {}, {}({}), {}({})".format(
+            rec.name = "{} {}, {}({}), {}({}), {}min".format(
                 rec.replenish_method,
                 rec.item_type,
                 rec.lead_time_id.name,
                 rec.lead_time_id.factor,
                 rec.variability_id.name,
                 rec.variability_id.factor,
+                rec.distributed_reschedule_max_proc_time,
             )
 
     name = fields.Char(string="Name", compute="_compute_name", store=True)
@@ -61,4 +63,12 @@ class StockBufferProfile(models.Model):
         default=False,
         help="When activated, the recommended quantity will be maxed at "
         "the quantity available in the replenishment source location.",
+    )
+    distributed_reschedule_max_proc_time = fields.Float(
+        string="Re-Schedule Procurement Max Proc. Time (minutes)",
+        default=0.0,
+        help="When you request procurement from a buffer, their scheduled"
+        " date is rescheduled to now + this procurement time (in minutes)."
+        " Their scheduled date represents the latest the transfers should"
+        " be done, and therefore, past this timestamp, considered late.",
     )

--- a/ddmrp/tests/__init__.py
+++ b/ddmrp/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_ddmrp
 from . import test_ddmrp_distributed_source_location
+from . import test_distributed_max_proc_time

--- a/ddmrp/tests/test_distributed_max_proc_time.py
+++ b/ddmrp/tests/test_distributed_max_proc_time.py
@@ -1,0 +1,128 @@
+# Copyright 2020 Camptocamp
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from freezegun import freeze_time
+
+from odoo import fields
+
+from .common import TestDdmrpCommon
+
+
+class TestDdmrpMaxProcTime(TestDdmrpCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # we store goods in "Replenish" and make pull rules to
+        # go through "Replenish Step" when we replenish Stock
+        cls.replenish_location = cls.env["stock.location"].create(
+            {
+                "name": "Replenish",
+                "location_id": cls.warehouse.view_location_id.id,
+                "usage": "internal",
+                "company_id": cls.main_company.id,
+            }
+        )
+        replenish_step_location = cls.env["stock.location"].create(
+            {
+                "name": "Replenish Step",
+                "location_id": cls.warehouse.view_location_id.id,
+                "usage": "internal",
+                "company_id": cls.main_company.id,
+            }
+        )
+
+        replenish_route = cls.env["stock.location.route"].create(
+            {"name": "Replenish", "sequence": 1}
+        )
+        cls.env["stock.rule"].create(
+            {
+                "name": "Replenish",
+                "route_id": replenish_route.id,
+                "location_src_id": cls.replenish_location.id,
+                "location_id": replenish_step_location.id,
+                "action": "pull",
+                "picking_type_id": cls.warehouse.int_type_id.id,
+                "procure_method": "make_to_stock",
+                "warehouse_id": cls.warehouse.id,
+                "company_id": cls.main_company.id,
+            }
+        )
+        cls.env["stock.rule"].create(
+            {
+                "name": "Replenish Step",
+                "route_id": replenish_route.id,
+                "location_src_id": replenish_step_location.id,
+                "location_id": cls.warehouse.lot_stock_id.id,
+                "action": "pull",
+                "picking_type_id": cls.warehouse.int_type_id.id,
+                "procure_method": "make_to_order",
+                "warehouse_id": cls.warehouse.id,
+                "company_id": cls.main_company.id,
+            }
+        )
+
+        # our product uses the replenishment route
+        cls.product_c_orange.route_ids = replenish_route
+
+        cls.buffer_dist = cls.bufferModel.create(
+            {
+                "buffer_profile_id": cls.buffer_profile_distr.id,
+                "product_id": cls.product_c_orange.id,
+                "location_id": cls.stock_location.id,
+                "warehouse_id": cls.warehouse.id,
+                "qty_multiple": 1.0,
+                "adu_calculation_method": cls.adu_fixed.id,
+                "adu_fixed": 5.0,
+            }
+        )
+
+    @freeze_time("2020-12-10 10:00:00")
+    def test_reschedule_proc_time_no_calendar(self):
+        """Reschedule moves based on the proc time"""
+        self.buffer_profile_distr.distributed_reschedule_max_proc_time = 180
+        self.warehouse.calendar_id = False
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_c_orange, self.replenish_location, 4000
+        )
+        # lie about the recommended qty to force creation of replenishment
+        self.buffer_dist.procure_recommended_qty = 10000
+
+        self.create_orderpoint_procurement(self.buffer_dist)
+        moves = self.env["stock.move"].search(
+            [("product_id", "=", self.product_c_orange.id)]
+        )
+
+        self.assertRecordValues(
+            moves,
+            [
+                {"date_expected": fields.Datetime.to_datetime("2020-12-11 13:00:00")},
+                {"date_expected": fields.Datetime.to_datetime("2020-12-11 13:00:00")},
+            ],
+        )
+
+    @freeze_time("2020-12-10 10:00:00")
+    def test_reschedule_proc_time_with_calendar(self):
+        """Reschedule moves based on the proc time with calendar"""
+        self.buffer_profile_distr.distributed_reschedule_max_proc_time = 90
+
+        self.env["stock.quant"]._update_available_quantity(
+            self.product_c_orange, self.replenish_location, 4000
+        )
+        # lie about the recommended qty to force creation of replenishment
+        self.buffer_dist.procure_recommended_qty = 10000
+
+        self.create_orderpoint_procurement(self.buffer_dist)
+        moves = self.env["stock.move"].search(
+            [("product_id", "=", self.product_c_orange.id)]
+        )
+
+        self.assertRecordValues(
+            moves,
+            [
+                # the start of the working hours is 7:00 (UTC), should be 8:00
+                # + 1:30 hour = 8:30
+                {"date_expected": fields.Datetime.to_datetime("2020-12-11 08:30:00")},
+                {"date_expected": fields.Datetime.to_datetime("2020-12-11 08:30:00")},
+            ],
+        )

--- a/ddmrp/views/stock_buffer_profile_view.xml
+++ b/ddmrp/views/stock_buffer_profile_view.xml
@@ -34,6 +34,7 @@
                             attrs="{'invisible': [('item_type', '!=', 'distributed')]}"
                         >
                             <field name="replenish_distributed_limit_to_free_qty" />
+                            <field name="distributed_reschedule_max_proc_time" />
                         </group>
                     </group>
                 </sheet>

--- a/ddmrp/wizards/make_procurement_buffer.py
+++ b/ddmrp/wizards/make_procurement_buffer.py
@@ -116,13 +116,7 @@ class MakeProcurementBuffer(models.TransientModel):
                 raise ValidationError(_("Quantity must be positive."))
             if not item.buffer_id:
                 raise ValidationError(_("No stock buffer found."))
-            values = item.buffer_id._prepare_procurement_values(item.qty)
-            values.update(
-                {
-                    "date_planned": fields.Datetime.to_string(item.date_planned),
-                    "supplier_id": self.partner_id if self.partner_id else False,
-                }
-            )
+            values = item._prepare_values_make_procurement()
             procurements.append(
                 pg_obj.Procurement(
                     item.buffer_id.product_id,
@@ -165,7 +159,7 @@ class MakeProcurementBufferItem(models.TransientModel):
     qty = fields.Float(string="Qty")
     qty_without_security = fields.Float(string="Quantity")
     uom_id = fields.Many2one(string="Unit of Measure", comodel_name="uom.uom",)
-    date_planned = fields.Date(string="Planned Date", required=False,)
+    date_planned = fields.Datetime(string="Planned Date", required=False)
     buffer_id = fields.Many2one(
         string="Stock Buffer", comodel_name="stock.buffer", readonly=False,
     )
@@ -185,3 +179,10 @@ class MakeProcurementBufferItem(models.TransientModel):
             rec.qty = rec.buffer_id.product_uom._compute_quantity(
                 rec.buffer_id.procure_recommended_qty, rec.uom_id
             )
+
+    def _prepare_values_make_procurement(self):
+        values = self.buffer_id._prepare_procurement_values(self.qty)
+        values.update(
+            {"date_planned": self.date_planned, "supplier_id": self.wiz_id.partner_id}
+        )
+        return values

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+freezegun


### PR DESCRIPTION
Add a configurable time for replenishment procurement on the profile.
This time is added to the planned datetime for the new moves, so they
are considered late when the replenishment time is overpassed.

To be able to do this, I had to change the "date_planned" field on
the procurement wizard from Date to Datetime.