### PR TITLE
[13.0][FIX] ddmrp_packaging: propagate contained qty changes

### DIFF
--- a/ddmrp/wizards/make_procurement_buffer_view.xml
+++ b/ddmrp/wizards/make_procurement_buffer_view.xml
@@ -79,5 +79,6 @@
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="binding_model_id" ref="ddmrp.model_stock_buffer" />
+        <field name="view_id" ref="ddmrp.view_make_procurement_buffer_wizard" />
     </record>
 </odoo>


### PR DESCRIPTION
* When the contained quantity of a packaging is updated, it should update the multiple quantity in all the buffers where it is used.
* extra fix in ddmrp: explicitly set the default wizard view.

@ForgeFlow