### PR TITLE
[13.0] Add queue.job.function for ddmrp_buffer._calc_adu

### DIFF
--- a/ddmrp_cron_actions_as_job/data/queue_job_function_data.xml
+++ b/ddmrp_cron_actions_as_job/data/queue_job_function_data.xml
@@ -4,4 +4,9 @@
         <field name="method">cron_actions</field>
         <field name="channel_id" ref="channel_ddmrp" />
     </record>
+    <record id="job_function_stock_buffer_calc_adu" model="queue.job.function">
+        <field name="model_id" ref="ddmrp.model_stock_buffer" />
+        <field name="method">_calc_adu</field>
+        <field name="channel_id" ref="channel_ddmrp" />
+    </record>
 </odoo>


### PR DESCRIPTION
With root.ddmrp as default channel.
It was done for "cron_actions" but missing for "_calc_adu".