### PR TITLE
[13.0][IMP] ddmrp_sale: able to exclude sale order lines form ADU.

### DIFF
--- a/ddmrp_sale/__manifest__.py
+++ b/ddmrp_sale/__manifest__.py
@@ -10,8 +10,8 @@
     "maintainers": ["LoisRForgeFlow"],
     "website": "https://github.com/OCA/ddmrp",
     "category": "Warehouse Management",
-    "depends": ["ddmrp", "sale_order_line_date"],
-    "data": ["views/stock_buffer_view.xml"],
+    "depends": ["ddmrp", "sale_order_line_date", "ddmrp_exclude_moves_adu_calc"],
+    "data": ["views/stock_buffer_view.xml", "views/sale_order_view.xml"],
     "license": "LGPL-3",
     "installable": True,
 }

--- a/ddmrp_sale/models/__init__.py
+++ b/ddmrp_sale/models/__init__.py
@@ -1,1 +1,2 @@
 from . import stock_buffer
+from . import sale_order_line

--- a/ddmrp_sale/models/sale_order_line.py
+++ b/ddmrp_sale/models/sale_order_line.py
@@ -1,0 +1,22 @@
+# Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    exclude_from_adu = fields.Boolean(
+        string="Exclude from ADU calculation",
+        copy=False,
+        help="If this flag is set related stock moves will be excluded from "
+        "ADU calculation",
+    )
+
+    def write(self, vals):
+        if "exclude_from_adu" in vals:
+            self.mapped("move_ids").write(
+                {"exclude_from_adu": vals.get("exclude_from_adu")}
+            )
+        return super().write(vals)

--- a/ddmrp_sale/views/sale_order_view.xml
+++ b/ddmrp_sale/views/sale_order_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
+<odoo>
+    <record id="view_order_form" model="ir.ui.view">
+        <field name="name">sale.order.form - ddmrp_sale</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_order_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='order_line']/tree" position="inside">
+                <field
+                    name="exclude_from_adu"
+                    optional="hide"
+                    widget="boolean_toggle"
+                    attrs="{'column_invisible': [('parent.state', 'not in', ['sale', 'done'])]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Includes a toggle switch in the sales order lines to exclude related moves from ADU calculation.

![image](https://user-images.githubusercontent.com/23449160/111438844-0564a400-8705-11eb-9573-8c1df073e226.png)

Pending:
* Be able to exclude quotation lines without moves?
* security, who should have access to this feature? sales manager only?

Extra:
* Should quotation in the past be considered as qualified demand or should they be discarded?


@ForgeFlow