### PR TITLE
[13.0][FIX] ddmrp: incorrect default ordering.

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -47,7 +47,7 @@ DDMRP_COLOR = {
 class StockBuffer(models.Model):
     _name = "stock.buffer"
     _description = "Stock Buffer"
-    _order = "planning_priority_level asc, net_flow_position asc"
+    _order = "planning_priority_level asc, net_flow_position_percent asc"
 
     CRON_DDMRP_CHUNKS = 50
 


### PR DESCRIPTION
Default prioritization in DDMRP is color first, NFP percentage(!) second.

@ForgeFlow

I can only describe my feelings now with this image:
![image](https://user-images.githubusercontent.com/23449160/112661281-a4e90b80-8e56-11eb-9b4e-20a6b244de4a.png)
