### PR TITLE
[13.0][IMP] ddmrp: add ddmrp_qty_multiple_tolerance option.

### DIFF
--- a/ddmrp/models/res_company.py
+++ b/ddmrp/models/res_company.py
@@ -16,3 +16,4 @@ class ResCompany(models.Model):
     ddmrp_adu_calc_include_scrap = fields.Boolean(
         string="Include scrap locations in ADU calculation",
     )
+    ddmrp_qty_multiple_tolerance = fields.Float(string="Qty Multiple Tolerance",)

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -485,8 +485,16 @@ class StockBuffer(models.Model):
         # Apply qty multiple and minimum quantity (maximum quantity
         # applies on the procure wizard)
         remainder = self.qty_multiple > 0 and adjusted_qty % self.qty_multiple or 0.0
-        if float_compare(remainder, 0.0, precision_rounding=rounding) > 0:
+        multiple_tolerance = self.qty_multiple * (
+            self.company_id.ddmrp_qty_multiple_tolerance / 100
+        )
+        if (
+            float_compare(remainder, multiple_tolerance, precision_rounding=rounding)
+            > 0
+        ):
             adjusted_qty += self.qty_multiple - remainder
+        elif float_compare(remainder, 0.0, precision_rounding=rounding) > 0:
+            adjusted_qty -= remainder
         if (
             float_compare(
                 adjusted_qty, self.procure_min_qty, precision_rounding=rounding

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -61,6 +61,9 @@ class TestDdmrpCommon(common.SavepointCase):
         cls.buffer_profile_distr = cls.env.ref(
             "ddmrp.stock_buffer_profile_replenish_distributed_medium_medium"
         )
+        cls.buffer_profile_override = cls.env.ref(
+            "ddmrp.stock_buffer_profile_replenish_override_purchased_short_low"
+        )
         cls.adu_fixed = cls.env.ref("ddmrp.adu_calculation_method_fixed")
         cls.group_stock_manager = cls.env.ref("stock.group_stock_manager")
         cls.group_mrp_user = cls.env.ref("mrp.group_mrp_user")

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -777,6 +777,39 @@ class TestDdmrp(TestDdmrpCommon):
         self.assertEqual(len(pol), 1)
         self.assertEqual(self.buffer_purchase.procure_recommended_qty, 0)
 
+    def test_27_qty_multiple_tolerance(self):
+        buffer = self.bufferModel.create(
+            {
+                "buffer_profile_id": self.buffer_profile_override.id,
+                "product_id": self.product_purchased.id,
+                "location_id": self.stock_location.id,
+                "warehouse_id": self.warehouse.id,
+                "qty_multiple": 250.0,
+                "adu_calculation_method": self.adu_fixed.id,
+                "adu_fixed": 5.0,
+                "green_override": 250.0,
+                "yellow_override": 10.0,
+                "red_override": 10.0,
+            }
+        )
+        date_move = datetime.today()
+        self.create_picking_out(self.product_purchased, date_move, 2)
+        buffer.cron_actions()
+        self.assertEqual(buffer.net_flow_position, -2.0)
+        self.assertEqual(buffer.procure_recommended_qty, 500)
+        # Set the tolerance
+        buffer.company_id.ddmrp_qty_multiple_tolerance = 10.0
+        # Tolerance: 10% 250 = 25, strictly needed 272 (under tolerance)
+        buffer.cron_actions()
+        self.assertEqual(buffer.procure_recommended_qty, 250)
+        # Add more demand
+        self.create_picking_out(self.product_purchased, date_move, 20)
+        buffer.cron_actions()
+        self.assertEqual(buffer.net_flow_position, -22.0)
+        # Tolerance: 10% 250 = 25, strictly needed 294 (above tolerance)
+        buffer.cron_actions()
+        self.assertEqual(buffer.procure_recommended_qty, 500)
+
     # TEST SECTION 3: DLT, BoM's and misc
 
     def test_30_bom_buffer_fields(self):

--- a/ddmrp/wizards/res_config_settings.py
+++ b/ddmrp/wizards/res_config_settings.py
@@ -31,3 +31,6 @@ class ResConfigSettings(models.TransientModel):
     ddmrp_adu_calc_include_scrap = fields.Boolean(
         related="company_id.ddmrp_adu_calc_include_scrap", readonly=False
     )
+    ddmrp_qty_multiple_tolerance = fields.Float(
+        related="company_id.ddmrp_qty_multiple_tolerance", readonly=False
+    )

--- a/ddmrp/wizards/res_config_settings_views.xml
+++ b/ddmrp/wizards/res_config_settings_views.xml
@@ -139,6 +139,26 @@
                                 <label for="ddmrp_adu_calc_include_scrap" />
                             </div>
                         </div>
+                        <div class="col-12 col-lg-6 o_setting_box">
+                            <div class="o_setting_left_pane" />
+                            <div class="o_setting_right_pane">
+                                <label for="ddmrp_qty_multiple_tolerance" />
+                                <span
+                                    class="fa fa-lg fa-building-o"
+                                    title="Values set here are company-specific."
+                                    role="img"
+                                    aria-label="Values set here are company-specific."
+                                    groups="base.group_multi_company"
+                                />
+                                <div class="text-muted">
+                                    Set a tolerance value to apply to quantity multiple in stock buffers.
+                                    If the quantity needed is below this tolerance threshold, the recommended
+                                    quantity will be reduced a bit instead of adding another bucket.
+                                    The value is a percentage of the quantity multiple.
+                                    <field name="ddmrp_qty_multiple_tolerance" />%
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </xpath>


### PR DESCRIPTION
Set a tolerance value to apply to quantity multiple in stock
buffers. If the quantity needed is below this tolerance
threshold, the recommended quantity will be reduced a bit
instead of adding another bucket. The value is a percentage
of the quantity multiple.

![image](https://user-images.githubusercontent.com/23449160/112962035-3ce04100-9146-11eb-8632-c6e3973a9ee4.png)


@ForgeFlow