### PR TITLE
[13.0][FIX] stock_buffer_capacity_limit: only consider qty on buffered location.

### DIFF
--- a/stock_buffer_capacity_limit/models/stock_buffer.py
+++ b/stock_buffer_capacity_limit/models/stock_buffer.py
@@ -2,6 +2,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
+from odoo.tools import float_compare
 
 
 class StockBuffer(models.Model):
@@ -20,11 +21,38 @@ class StockBuffer(models.Model):
         res = super()._compute_procure_recommended_qty()
         for rec in self.filtered(lambda b: b.storage_capacity_limit > 0.0):
             recommendation_limit = max(
-                rec.storage_capacity_limit
-                - rec.product_id.qty_available
+                rec.storage_capacity_limit  # UoM of the product
+                - rec.product_location_qty
                 - rec.incoming_dlt_qty,
                 0,
             )
-            qty = min(rec.procure_recommended_qty, recommendation_limit)
-            rec.procure_recommended_qty = qty
+            if rec.procure_uom_id:
+                rounding = rec.procure_uom_id.rounding
+                limit_uom = rec.product_id.uom_id._compute_quantity(
+                    recommendation_limit, rec.procure_uom_id
+                )
+            else:
+                rounding = rec.product_uom.rounding
+                limit_uom = recommendation_limit
+
+            if (
+                float_compare(
+                    limit_uom, rec.procure_recommended_qty, precision_rounding=rounding
+                )
+                > 0
+            ):
+                # Recommendation is valid.
+                continue
+
+            new_recommendation = limit_uom
+            if (
+                float_compare(
+                    rec.procure_min_qty, limit_uom, precision_rounding=rounding
+                )
+                > 0
+            ):
+                new_recommendation = 0
+            elif rec.qty_multiple:
+                new_recommendation -= new_recommendation % rec.qty_multiple
+            rec.procure_recommended_qty = new_recommendation
         return res

--- a/stock_buffer_capacity_limit/tests/test_stock_buffer_capacity_limit.py
+++ b/stock_buffer_capacity_limit/tests/test_stock_buffer_capacity_limit.py
@@ -1,4 +1,4 @@
-# Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
+# Copyright 2020-21 ForgeFlow S.L. (https://www.forgeflow.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import fields
@@ -7,6 +7,11 @@ from odoo.addons.ddmrp.tests.common import TestDdmrpCommon
 
 
 class TestBufferCapacityLimit(TestDdmrpCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.uom_dozen = cls.env.ref("uom.product_uom_dozen")
+
     def test_01_storage_capacity_limit(self):
         self.assertEqual(self.buffer_a.top_of_green, 90)
         self.assertEqual(self.buffer_a.net_flow_position, 200)
@@ -25,4 +30,59 @@ class TestBufferCapacityLimit(TestDdmrpCommon):
         p_in_1 = self.create_pickinginA(date_move, 10)
         p_in_1.action_confirm()
         self.buffer_a.cron_actions()
+        self.assertEqual(self.buffer_a.procure_recommended_qty, 0)
+
+    def test_02_storage_limit_and_qty_multiple(self):
+        self.buffer_a.qty_multiple = 50
+        self.assertEqual(self.buffer_a.top_of_green, 90)
+        self.assertEqual(self.buffer_a.net_flow_position, 200)
+        date_move = fields.Datetime.now()
+        p_out_1 = self.create_pickingoutA(date_move, 180)
+        p_out_1.action_confirm()
+        self.buffer_a.cron_actions()
+        self.assertEqual(self.buffer_a.net_flow_position, 20)
+        # 70 adjusted by qty multiple to 100
+        self.assertEqual(self.buffer_a.procure_recommended_qty, 100)
+        self.buffer_a.storage_capacity_limit = 310
+        self.buffer_a.cron_actions()
+        # 70 unadjusted, 110 more to reach limit, adjusted to 100 because
+        # 100 is possible
+        self.assertEqual(self.buffer_a.procure_recommended_qty, 100)
+        self.buffer_a.storage_capacity_limit = 275
+        self.buffer_a.cron_actions()
+        # 70 unadjusted, 75 more to reach limit, adjusted to 50 because
+        # 100 is not possible
+        self.assertEqual(self.buffer_a.procure_recommended_qty, 50)
+        self.buffer_a.storage_capacity_limit = 240
+        self.buffer_a.cron_actions()
+        # 70 unadjusted, 40 more to reach limit, adjusted to 0 because
+        # 50 is not possible
+        self.assertEqual(self.buffer_a.procure_recommended_qty, 0)
+
+    def test_03_storage_limit_and_qty_multiple_uom(self):
+        self.buffer_a.qty_multiple = 2
+        self.buffer_a.procure_uom_id = self.uom_dozen
+        self.assertEqual(self.buffer_a.top_of_green, 90)
+        self.assertEqual(self.buffer_a.net_flow_position, 200)
+        date_move = fields.Datetime.now()
+        p_out_1 = self.create_pickingoutA(date_move, 180)
+        p_out_1.action_confirm()
+        self.buffer_a.cron_actions()
+        self.assertEqual(self.buffer_a.net_flow_position, 20)
+        # 70 units adjusted by qty multiple and uom to 6 dozens.
+        self.assertEqual(self.buffer_a.procure_recommended_qty, 6)
+        self.buffer_a.storage_capacity_limit = 310
+        self.buffer_a.cron_actions()
+        # 70 unadjusted, 110 more to reach limit (9.5 dozens), adjusted to 6
+        # dozens because it is a valid proposal.
+        self.assertEqual(self.buffer_a.procure_recommended_qty, 6)
+        self.buffer_a.storage_capacity_limit = 265
+        self.buffer_a.cron_actions()
+        # 70 unadjusted, 65 more to reach limit (5.4 dozens), adjusted to 4
+        # dozens because 6 is not possible.
+        self.assertEqual(self.buffer_a.procure_recommended_qty, 4)
+        self.buffer_a.storage_capacity_limit = 223
+        self.buffer_a.cron_actions()
+        # 70 unadjusted, 23 more to reach limit (1.9 dozens), adjusted to 0
+        # because the limit is less than the multiple of 2 dozens.
         self.assertEqual(self.buffer_a.procure_recommended_qty, 0)


### PR DESCRIPTION
Without this all quantity available for the buffered product was considering, leading to wrong recommendations.

@ForgeFlow