### PR TITLE
[13.0][REF] ddmrp_product_replace: add replace "modes".

### DIFF
--- a/ddmrp_product_replace/__manifest__.py
+++ b/ddmrp_product_replace/__manifest__.py
@@ -11,7 +11,11 @@
     "website": "https://github.com/OCA/ddmrp",
     "category": "Warehouse Management",
     "depends": ["ddmrp"],
-    "data": ["wizards/ddmrp_product_replace_view.xml", "views/stock_buffer_view.xml"],
+    "data": [
+        "wizards/ddmrp_product_replace_view.xml",
+        "wizards/make_procurement_buffer_view.xml",
+        "views/stock_buffer_view.xml",
+    ],
     "license": "LGPL-3",
     "installable": True,
 }

--- a/ddmrp_product_replace/models/stock_buffer.py
+++ b/ddmrp_product_replace/models/stock_buffer.py
@@ -8,11 +8,43 @@ from odoo.exceptions import ValidationError
 class StockBuffer(models.Model):
     _inherit = "stock.buffer"
 
+    replaced_by_id = fields.Many2one(
+        comodel_name="stock.buffer",
+        string="Replaced by",
+        help="The product in this buffer is replaced by the product of selected "
+        "buffer. When you replace another buffer:\n - Past Demand of the "
+        "replacement buffer will include the past demand of this product\n"
+        " - Several buffers can be replaced in chained and coexist at the "
+        "same time: A replaces B that replaces C, then A aggregates both B"
+        " and C where B only aggregates C",
+        tracking=True,
+    )
+    replaced_by_alert_text = fields.Char(compute="_compute_replaced_by_alert_text",)
+    replacement_for_ids = fields.One2many(
+        string="Replaces", comodel_name="stock.buffer", inverse_name="replaced_by_id",
+    )
+    replacement_for_count = fields.Integer(compute="_compute_replacement_for_count",)
+    is_replacement_product = fields.Boolean(
+        string="Replacement Product",
+        compute="_compute_is_replacement_product",
+        store=True,
+        help="The product of this buffer is replacing another product",
+    )
     demand_product_ids = fields.Many2many(
         comodel_name="product.product",
         string="Considered As Demand",
         help="This field is used for a correct product replacement within a "
         "DDMRP buffer.",
+    )
+    use_replacement_for_buffer_status = fields.Boolean(
+        string="Include Incoming & On-Hands of replaced products",
+        compute="_compute_use_replacement_for_buffer_status",
+        store=True,
+        readonly=False,
+        copy=False,
+        help="If you tick this option, the buffer will consider the incoming "
+        "and on-hand of all products it replaces and this will impact its "
+        "NFP.",
     )
 
     @api.constrains("demand_product_ids")
@@ -23,6 +55,45 @@ class StockBuffer(models.Model):
                     _("Buffered product must be considered as demand.")
                 )
 
+    def _compute_replaced_by_alert_text(self):
+        for rec in self:
+            if rec.replaced_by_id:
+                rec.replaced_by_alert_text = (
+                    _("This product is replaced by %s.")
+                    % rec.replaced_by_id.product_id.display_name
+                )
+            else:
+                rec.replaced_by_alert_text = ""
+
+    def _compute_replacement_for_count(self):
+        for rec in self:
+            rec.replacement_for_count = len(rec.replacement_for_ids)
+
+    @api.depends("replaced_by_id", "replacement_for_ids", "replacement_for_ids.active")
+    def _compute_is_replacement_product(self):
+        for rec in self:
+            rec.is_replacement_product = (
+                rec.replacement_for_ids and not rec.replaced_by_id
+            )
+
+    @api.depends("item_type")
+    def _compute_use_replacement_for_buffer_status(self):
+        for rec in self:
+            rec.use_replacement_for_buffer_status = rec.item_type in [
+                "manufactured",
+                "purchased",
+            ]
+
+    @api.depends("item_type")
+    def _compute_procure_recommended_qty(self):
+        replaced = self.filtered(
+            lambda r: r.replaced_by_id and r.item_type in ["manufactured", "purchased"]
+        )
+        res = super(StockBuffer, self - replaced)._compute_procure_recommended_qty()
+        for rec in replaced:
+            rec.procure_recommended_qty = 0.0
+        return res
+
     def _past_moves_domain(self, date_from, date_to, locations):
         if not self.demand_product_ids:
             return super()._past_moves_domain(date_from, date_to, locations)
@@ -31,6 +102,56 @@ class StockBuffer(models.Model):
         for n, clause in enumerate(domain):
             if isinstance(clause, tuple) and clause[0] == "product_id":
                 index_replace = n
-        if index_replace:
+        if isinstance(index_replace, int):
             domain[index_replace] = ("product_id", "in", self.demand_product_ids.ids)
         return domain
+
+    @api.model
+    def _recursive_replacement_for_ids(self, buffers):
+        """ Returns the list of buffers being replaced recursively.
+        """
+        res = self.env["stock.buffer"]
+        for rec in buffers:
+            if rec.replacement_for_ids:
+                res += self._recursive_replacement_for_ids(rec.replacement_for_ids)
+            res += rec
+        return res
+
+    def _compute_product_available_qty(self):
+        res = super()._compute_product_available_qty()
+        for rec in self:
+            if not (rec.use_replacement_for_buffer_status and rec.replacement_for_ids):
+                continue
+            for buffer in rec.replacement_for_ids:
+                replacements_qty = buffer.product_uom._compute_quantity(
+                    buffer.product_location_qty_available_not_res,
+                    rec.product_uom,
+                    round=False,
+                )
+                rec.product_location_qty_available_not_res += replacements_qty
+        return res
+
+    def _search_stock_moves_incoming_domain(self, outside_dlt=False):
+        domain = super()._search_stock_moves_incoming_domain(outside_dlt=outside_dlt)
+        if not (self.use_replacement_for_buffer_status and self.replacement_for_ids):
+            return domain
+        index_replace = False
+        for n, clause in enumerate(domain):
+            if isinstance(clause, tuple) and clause[0] == "product_id":
+                index_replace = n
+        if isinstance(index_replace, int):
+            domain[index_replace] = (
+                "product_id",
+                "in",
+                (self + self._recursive_replacement_for_ids(self.replacement_for_ids))
+                .mapped("product_id")
+                .ids,
+            )
+        return domain
+
+    def action_view_buffers_replaced(self):
+        action = self.env.ref("ddmrp.action_stock_buffer")
+        result = action.read()[0]
+        result["name"] = _("Buffers Replaced")
+        result["domain"] = [("id", "in", self.replacement_for_ids.ids)]
+        return result

--- a/ddmrp_product_replace/readme/USAGE.rst
+++ b/ddmrp_product_replace/readme/USAGE.rst
@@ -1,1 +1,5 @@
 Go to *Inventory > Configuration > DDMRP > Product Replacement Tool*.
+
+Then you can fill the wizard options to complete the replacement. There are two
+modes of operation: *Create a new buffer for the replacing product* and
+*Replace product in existing buffers*.

--- a/ddmrp_product_replace/tests/test_product_replace.py
+++ b/ddmrp_product_replace/tests/test_product_replace.py
@@ -32,7 +32,7 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
         method = cls.env.ref("ddmrp.adu_calculation_method_past_120")
         cls.buffer.adu_calculation_method = method
 
-    def test_product_replace(self):
+    def test_01_product_replace_use_existing(self):
         date_move = datetime.today() - timedelta(days=30)
         picking = self.create_picking_out(self.old_product, date_move, 60)
         self._do_picking(picking, date_move)
@@ -44,7 +44,8 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
 
         wiz = self.env["ddmrp.product.replace"].create(
             {
-                "old_product_id": self.buffer.product_id.id,
+                "mode": "use_existing",
+                "old_product_ids": [(6, 0, self.buffer.product_id.ids)],
                 "use_existing": "new",
                 "new_product_name": "RM-01 Replacement",
                 "new_product_default_code": "ABCDE012345",
@@ -75,3 +76,59 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
         self.assertIn(self.old_product, self.buffer.demand_product_ids)
         self.buffer._calc_adu()
         self.assertEqual(self.buffer.adu, adu_previous)
+
+    def test_02_product_replace_new_buffer(self):
+        # Complete one delivery
+        date_move = datetime.today() - timedelta(days=30)
+        picking = self.create_picking_out(self.old_product, date_move, 60)
+        self._do_picking(picking, date_move)
+        # and confirm an incoming
+        self.create_picking_in(self.old_product, datetime.today(), 30)
+        self.buffer.cron_actions()
+        self.assertEqual(self.buffer.product_id, self.old_product)
+        self.assertEqual(len(self.buffer.demand_product_ids), 0)
+        old_onhand = self.buffer.product_location_qty_available_not_res
+        self.assertEqual(old_onhand, -60.0)
+        old_incoming = self.buffer.incoming_dlt_qty
+        self.assertEqual(old_incoming, 30.0)
+        wiz = self.env["ddmrp.product.replace"].create(
+            {
+                "mode": "new_buffer",
+                "old_product_ids": [(6, 0, self.buffer.product_id.ids)],
+                "use_existing": "new",
+                "new_product_name": "RM-01 Replacement 2",
+                "new_product_default_code": "ABC000222",
+                "copy_route": True,
+                "copy_putaway": False,
+            }
+        )
+        self.assertEqual(wiz.buffer_ids, self.buffer)
+        self.assertFalse(wiz.is_already_replaced)
+        res = wiz.button_validate()
+        new_buffer_ids = res.get("domain")[0][2]
+        model = res.get("res_model")
+        self.assertEqual(model, "stock.buffer")
+        new_buffer = self.bufferModel.browse(new_buffer_ids)
+        self.assertEqual(len(new_buffer), 1)
+        self.assertNotEqual(self.buffer.id, new_buffer.id)
+        # Check new product
+        new_product = new_buffer.product_id
+        self.assertEqual(new_product.name, "RM-01 Replacement 2")
+        self.assertEqual(new_product.default_code, "ABC000222")
+        self.assertEqual(new_product.route_ids, self.old_product.route_ids)
+        self.assertNotEqual(self.buffer.product_id, new_product)
+        # Check replacing fields in buffers:
+        self.assertEqual(self.buffer.replaced_by_id, new_buffer)
+        self.assertTrue(new_buffer.is_replacement_product)
+        self.assertTrue(new_buffer.use_replacement_for_buffer_status)
+        # Check buffer values:
+        self.buffer.cron_actions()
+        self.assertEqual(old_onhand, new_buffer.product_location_qty_available_not_res)
+        self.assertEqual(old_incoming, new_buffer.incoming_dlt_qty)
+        new_buffer.invalidate_cache()
+        new_buffer.use_replacement_for_buffer_status = False
+        new_buffer.cron_actions()
+        self.assertNotEqual(
+            old_onhand, new_buffer.product_location_qty_available_not_res
+        )
+        self.assertNotEqual(old_incoming, new_buffer.incoming_dlt_qty)

--- a/ddmrp_product_replace/views/stock_buffer_view.xml
+++ b/ddmrp_product_replace/views/stock_buffer_view.xml
@@ -7,18 +7,77 @@
         <field name="model">stock.buffer</field>
         <field name="inherit_id" ref="ddmrp.stock_buffer_view_form" />
         <field name="arch" type="xml">
+            <sheet position="before">
+                <div
+                    class="alert alert-danger"
+                    role="alert"
+                    attrs="{'invisible': [('replaced_by_id', '=', False)]}"
+                    style="margin-bottom:0px;"
+                >
+                    <p>
+                        <i class="fa fa-info-circle" style="margin-right:5px" />
+                        <field name="replaced_by_alert_text" />
+                    </p>
+                </div>
+            </sheet>
+            <div name="button_box" position="inside">
+                <button
+                    type="object"
+                    name="action_view_buffers_replaced"
+                    class="oe_stat_button"
+                    icon="fa-signal"
+                    attrs="{'invisible': [('replacement_for_count', '=', 0)]}"
+                >
+                    <field
+                        name="replacement_for_count"
+                        widget="statinfo"
+                        string="Replacement for"
+                    />
+                </button>
+            </div>
+            <field name="product_id" position="after">
+                <field name="replaced_by_id" />
+            </field>
             <notebook position="inside">
                 <page
                     name="product_replacement"
                     string="Product Replacement"
-                    attrs="{'invisible': [('demand_product_ids','=',[])]}"
+                    attrs="{'invisible': [('demand_product_ids','=',[]), ('replacement_for_count', '=', 0)]}"
                     groups="stock.group_stock_manager"
                 >
                     <group>
                         <field name="demand_product_ids" widget="many2many_tags" />
+                        <field name="is_replacement_product" />
+                        <field name="use_replacement_for_buffer_status" />
                     </group>
                 </page>
             </notebook>
+        </field>
+    </record>
+    <record id="stock_buffer_view_tree" model="ir.ui.view">
+        <field name="name">stock.buffer.tree - ddmrp_product_replace</field>
+        <field name="model">stock.buffer</field>
+        <field name="inherit_id" ref="ddmrp.stock_buffer_view_tree" />
+        <field name="arch" type="xml">
+            <field name="top_of_green" position="after">
+                <field name="replaced_by_id" optional="hide" />
+                <field name="is_replacement_product" optional="hide" />
+            </field>
+        </field>
+    </record>
+    <record id="stock_buffer_search" model="ir.ui.view">
+        <field name="name">stock.buffer.search - ddmrp_product_replace</field>
+        <field name="model">stock.buffer</field>
+        <field name="inherit_id" ref="ddmrp.stock_buffer_search" />
+        <field name="arch" type="xml">
+            <filter name="has_distributed_source_location_qty" position="after">
+                <separator />
+                <filter
+                    name="is_replacement_product_filter"
+                    string="Replacement Product"
+                    domain="[('is_replacement_product', '=', True)]"
+                />
+            </filter>
         </field>
     </record>
 </odoo>

--- a/ddmrp_product_replace/wizards/__init__.py
+++ b/ddmrp_product_replace/wizards/__init__.py
@@ -1,1 +1,2 @@
 from . import ddmrp_product_replace
+from . import make_procurement_buffer

--- a/ddmrp_product_replace/wizards/ddmrp_product_replace.py
+++ b/ddmrp_product_replace/wizards/ddmrp_product_replace.py
@@ -2,36 +2,49 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class DdmrpProductReplace(models.TransientModel):
     _name = "ddmrp.product.replace"
     _description = "DDMRP Product Replace"
 
-    @api.depends("old_product_id")
-    def _compute_buffer_ids(self):
-        for rec in self:
-            rec.buffer_ids = self.env["stock.buffer"].search(
-                [("product_id", "=", rec.old_product_id.id)]
-            )
-
-    old_product_id = fields.Many2one(
+    old_product_ids = fields.Many2many(
         comodel_name="product.product",
-        string="Replaced Product",
+        string="Replaced Products",
         help="Product to be replaced.",
         required=True,
         ondelete="cascade",
     )
+    multi_product = fields.Boolean(compute="_compute_multi_product")
+    primary_old_product_id = fields.Many2one(
+        string="Primary Replaced Product",
+        comodel_name="product.product",
+        compute="_compute_primary_old_product_id",
+        store=True,
+        readonly=False,
+        domain="[('id', 'in', old_product_ids)]",
+    )
     buffer_ids = fields.Many2many(
         comodel_name="stock.buffer",
         string="Affected Buffers",
-        readonly=True,
+        readonly=False,
         compute="_compute_buffer_ids",
+        store=True,
     )
+    is_already_replaced = fields.Boolean(compute="_compute_is_already_replaced",)
     new_product_id = fields.Many2one(
         comodel_name="product.product",
         string="Substitute Product",
         help="Product that is going to replace the other one.",
+    )
+    mode = fields.Selection(
+        selection=[
+            ("new_buffer", "Create a new buffer for the replacing product."),
+            ("use_existing", "Replace product in existing buffers"),
+        ],
+        default="new_buffer",
+        required=True,
     )
     use_existing = fields.Selection(
         string="Use Existing/New Product",
@@ -48,39 +61,56 @@ class DdmrpProductReplace(models.TransientModel):
         default=True,
     )
 
-    def button_validate(self):
-        self.ensure_one()
-        if self.use_existing == "new":
-            default = dict(
-                name=self.new_product_name, default_code=self.new_product_default_code,
+    @api.depends("old_product_ids")
+    def _compute_multi_product(self):
+        for rec in self:
+            rec.multi_product = len(rec.old_product_ids) > 1
+
+    @api.depends("old_product_ids")
+    def _compute_primary_old_product_id(self):
+        for rec in self:
+            product = fields.first(rec.old_product_ids)
+            if isinstance(product.id, models.NewId):
+                # NewId instances are not handled correctly in v13, this is a
+                # small workaround. In future versions it might not be needed.
+                product_id = product.id.origin
+                product = self.env["product.product"].browse(product_id)
+            rec.primary_old_product_id = product
+
+    @api.depends("old_product_ids")
+    def _compute_buffer_ids(self):
+        for rec in self:
+            rec.buffer_ids = self.env["stock.buffer"].search(
+                [("product_id", "in", rec.old_product_ids.ids)]
             )
-            if not self.copy_route:
-                default["route_ids"] = None
-            self.new_product_id = self.old_product_id.copy(default=default)
-        elif self.use_existing == "existing":
-            if self.copy_route:
-                self.new_product_id.write(
-                    {"route_ids": [(6, 0, self.old_product_id.route_ids.ids)]}
+
+    @api.depends("buffer_ids")
+    def _compute_is_already_replaced(self):
+        for rec in self:
+            rec.is_already_replaced = any(b.replaced_by_id for b in rec.buffer_ids)
+
+    @api.constrains("buffer_ids")
+    def _check_buffer_ids(self):
+        for rec in self:
+            if rec.old_product_ids and any(
+                b.product_id not in rec.old_product_ids for b in rec.buffer_ids
+            ):
+                raise ValidationError(
+                    _(
+                        "Some of the affected buffers have a different product than "
+                        "the replaced ones."
+                    )
                 )
-        # Check if copy putaway strategies is True
-        if self.copy_putaway:
-            # Check if there exist putaway strategies for the from product
-            putaway_ids = self.env["stock.putaway.rule"].search(
-                [("product_id", "=", self.old_product_id.id)]
-            )
-            if putaway_ids:
-                # Copy putaway strategies
-                default_putaway = dict(product_id=self.new_product_id.id,)
-                putaway_ids.copy(default=default_putaway)
-        if self.buffer_ids:
-            vals = {
-                "product_id": self.new_product_id.id,
-            }
-            if self.consider_past_demand:
-                vals["demand_product_ids"] = [
-                    (6, 0, (self.old_product_id + self.new_product_id).ids)
-                ]
-            self.buffer_ids.write(vals)
+
+    def _do_replacement_use_existing(self):
+        vals = {
+            "product_id": self.new_product_id.id,
+        }
+        if self.consider_past_demand:
+            vals["demand_product_ids"] = [
+                (6, 0, (self.old_product_ids + self.new_product_id).ids)
+            ]
+        self.buffer_ids.write(vals)
         return {
             "name": _("Replacing Product"),
             "res_id": self.new_product_id.id,
@@ -89,3 +119,89 @@ class DdmrpProductReplace(models.TransientModel):
             "res_model": "product.product",
             "type": "ir.actions.act_window",
         }
+
+    def _do_replacement_new_buffer(self):
+        primary_old = self.primary_old_product_id
+        new_buffers = self.env["stock.buffer"]
+        for replaced in self.buffer_ids.filtered(lambda b: b.product_id == primary_old):
+            default = dict(
+                product_id=self.new_product_id.id,
+                auto_procure=False,
+                demand_product_ids=False,
+            )
+            replacing = replaced.copy(default=default)
+            replaced.write({"replaced_by_id": replacing.id})
+            new_buffers |= replacing
+        for replaced in self.buffer_ids.filtered(lambda b: b.product_id != primary_old):
+            # Do not create buffers for non-primary products.
+            # Instead assign one of the already created.
+            replacing = fields.first(
+                new_buffers.filtered(lambda b: b.location_id == replaced.location_id)
+            )
+            if not replacing:
+                replacing = new_buffers[0]
+            replaced.write({"replaced_by_id": replacing.id})
+        if self.consider_past_demand:
+            for buffer in new_buffers:
+                recursive_buffers = buffer._recursive_replacement_for_ids(
+                    buffer.replacement_for_ids
+                )
+                buffer.write(
+                    {
+                        "demand_product_ids": [
+                            (
+                                6,
+                                0,
+                                (
+                                    recursive_buffers.mapped("product_id")
+                                    + buffer.product_id
+                                ).ids,
+                            )
+                        ],
+                    }
+                )
+        new_buffers.cron_actions()
+        return {
+            "name": _("New Stock Buffers"),
+            "domain": [("id", "in", new_buffers.ids)],
+            "view_mode": "tree,form",
+            "res_model": "stock.buffer",
+            "type": "ir.actions.act_window",
+        }
+
+    def button_validate(self):
+        self.ensure_one()
+        if self.is_already_replaced:
+            raise ValidationError(_("Some of the buffers have already been replaced."))
+        if not self.buffer_ids:
+            raise ValidationError(_("No affected buffers found."))
+        # Only the first product is used as a template to create new products/buffers.
+        primary_old = self.primary_old_product_id
+        if self.use_existing == "new":
+            default = dict(
+                name=self.new_product_name, default_code=self.new_product_default_code,
+            )
+            if not self.copy_route:
+                default["route_ids"] = None
+            self.new_product_id = primary_old.copy(default=default)
+        elif self.use_existing == "existing":
+            if self.copy_route:
+                self.new_product_id.write(
+                    {"route_ids": [(6, 0, primary_old.route_ids.ids)]}
+                )
+        # Check if copy putaway strategies is True
+        if self.copy_putaway:
+            # Check if there exist putaway strategies for the from product
+            putaway_ids = self.env["stock.putaway.rule"].search(
+                [("product_id", "=", primary_old.id)]
+            )
+            if putaway_ids:
+                # Copy putaway strategies
+                default_putaway = dict(product_id=self.new_product_id.id,)
+                putaway_ids.copy(default=default_putaway)
+
+        if self.mode == "use_existing":
+            res = self._do_replacement_use_existing()
+        elif self.mode == "new_buffer":
+            res = self._do_replacement_new_buffer()
+        return res

--- a/ddmrp_product_replace/wizards/ddmrp_product_replace_view.xml
+++ b/ddmrp_product_replace/wizards/ddmrp_product_replace_view.xml
@@ -7,10 +7,31 @@
         <field name="model">ddmrp.product.replace</field>
         <field name="arch" type="xml">
             <form string="Product Replacement Tool">
+                <group>
+                    <field name="mode" />
+                </group>
                 <group name="old_product" string="Select Replaced Products">
-                    <field name="old_product_id" />
+                    <field
+                        name="old_product_ids"
+                        widget="many2many_tags"
+                        options="{'no_create': True}"
+                    />
+                    <field name="multi_product" invisible="1" />
+                    <div
+                        attrs="{'invisible': [('multi_product', '=', False)]}"
+                        colspan="2"
+                    >
+                        <p> <i class="fa fa-info-circle" style="margin-right:5px" />
+                            When there are more than one product replaced, only the buffer(s) of the primary product in
+                            this list will be used to create the buffer(s) and/or product(s) for replacement.
+                        </p>
+                    </div>
+                    <field
+                        name="primary_old_product_id"
+                        attrs="{'invisible': [('multi_product', '=', False)]}"
+                    />
                     <field name="buffer_ids">
-                        <tree>
+                        <tree decoration-danger="replaced_by_id">
                             <field name="name" />
                             <field name="warehouse_id" />
                             <field name="location_id" />
@@ -18,8 +39,10 @@
                                 name="company_id"
                                 groups="base.group_multi_company"
                             />
+                            <field name="replaced_by_id" optional="hide" />
                         </tree>
                     </field>
+                    <field name="is_already_replaced" invisible="1" />
                 </group>
                 <group name="new_product" string="Select Replacing Product">
                     <field name="use_existing" />

--- a/ddmrp_product_replace/wizards/make_procurement_buffer.py
+++ b/ddmrp_product_replace/wizards/make_procurement_buffer.py
@@ -1,0 +1,31 @@
+# Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import _, api, fields, models
+
+
+class MakeProcurementBuffer(models.TransientModel):
+    _inherit = "make.procurement.buffer"
+
+    has_replaced_buffers = fields.Boolean(compute="_compute_replaced_by_alert_text",)
+    replaced_by_alert_text = fields.Text(compute="_compute_replaced_by_alert_text",)
+
+    @api.depends("item_ids")
+    def _compute_replaced_by_alert_text(self):
+        for rec in self:
+            if any(r.buffer_id.replaced_by_id for r in rec.item_ids):
+                rec.has_replaced_buffers = True
+                alert_text = _("Some products are being replaced:")
+                for item in rec.item_ids:
+                    if item.buffer_id.replaced_by_id:
+                        replacement = item.buffer_id.replaced_by_id
+                        alert_text += "\n - {} ({}) replaced by {} ({})".format(
+                            item.buffer_id.display_name,
+                            item.buffer_id.product_id.display_name,
+                            replacement.display_name,
+                            replacement.product_id.display_name,
+                        )
+                rec.replaced_by_alert_text = alert_text
+            else:
+                rec.has_replaced_buffers = False
+                rec.replaced_by_alert_text = ""

--- a/ddmrp_product_replace/wizards/make_procurement_buffer_view.xml
+++ b/ddmrp_product_replace/wizards/make_procurement_buffer_view.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="view_make_procurement_buffer_wizard" model="ir.ui.view">
+        <field name="name">Request Procurement</field>
+        <field name="model">make.procurement.buffer</field>
+        <field name="inherit_id" ref="ddmrp.view_make_procurement_buffer_wizard" />
+        <field name="arch" type="xml">
+            <xpath expr="//p[hasclass('oe_gray')][last()]" position="after">
+                <div
+                    class="alert alert-danger"
+                    role="alert"
+                    attrs="{'invisible': [('has_replaced_buffers', '=', False)]}"
+                    style="margin-bottom:0px;"
+                >
+                    <p>
+                        <span class="fa fa-info-circle" style="margin-right:5px" />
+                        <field name="replaced_by_alert_text" style="display:inline;" />
+                    </p>
+                </div>
+            </xpath>
+            <field name="partner_id" position="after">
+                <field name="has_replaced_buffers" invisible="1" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Some of the main changes included are:
* replacement can be done to a new buffer, instead of changing
  the product of the replaced buffer. (new mode "new_buffer")
* In the new mode buffers are related via `replaced_by_id` field.
* Boolean `use_replacement_for_buffer_status` allow to consider
  buffers being replaced in NFP (via on-hand and incoming).
* warnings shown for products being replaced when procuring, and
  procure recommendation is now 0 if the buffer is not
  distributed.
* Views adaptations and improvements.
* Old funtionality kept in mode "use_existing".

To Do:
* [x] : Update README.
* [x] : Add tests.

cc @jgrandguillaume @jbaudoux 

@ForgeFlow