### PR TITLE
[13.0][FIX] ddmrp: do not show distributed_reschedule_max_proc_time in profile name if not in use.

### DIFF
--- a/ddmrp/models/stock_buffer_profile.py
+++ b/ddmrp/models/stock_buffer_profile.py
@@ -33,15 +33,17 @@ class StockBufferProfile(models.Model):
     def _compute_name(self):
         """Get the right summary for this job."""
         for rec in self:
-            rec.name = "{} {}, {}({}), {}({}), {}min".format(
+            name = "{} {}, {}({}), {}({})".format(
                 rec.replenish_method,
                 rec.item_type,
                 rec.lead_time_id.name,
                 rec.lead_time_id.factor,
                 rec.variability_id.name,
                 rec.variability_id.factor,
-                rec.distributed_reschedule_max_proc_time,
             )
+            if rec.distributed_reschedule_max_proc_time > 0.0:
+                name += ", {}min".format(rec.distributed_reschedule_max_proc_time)
+            rec.name = name
 
     name = fields.Char(string="Name", compute="_compute_name", store=True)
     replenish_method = fields.Selection(


### PR DESCRIPTION
This can be noise for non distributed profiles and for implementations not using the feature.

cc @jgrandguillaume 

@ForgeFlow