### PR TITLE
[13.0][FIX] main supplier compute

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -748,7 +748,15 @@ class StockBuffer(models.Model):
         sellers = sellers.sorted(key="sequence")
         return sellers
 
-    @api.depends("buffer_profile_id", "product_id.seller_ids")
+    @api.depends(
+        "buffer_profile_id",
+        "item_type",
+        "product_id.seller_ids",
+        "product_id.seller_ids.company_id",
+        "product_id.seller_ids.name",
+        "product_id.seller_ids.product_id",
+        "product_id.seller_ids.sequence",
+    )
     def _compute_main_supplier(self):
         for rec in self:
             if rec.item_type == "purchased":


### PR DESCRIPTION
Updates the `@api.depends` fields on the `_compute_main_supplier` method.

When a `product_supplierinfo` is directly updated (not from the product), the method is never called, and therefore the main_supplier_id isn't updated.

Only the last commit is relevant, others are coming from other opened PRs.