### PR TITLE
[13.0][FIX] ddmrp: since date planned is now a datetime, the limit for incoming should also be

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -226,10 +226,12 @@ class StockBuffer(models.Model):
 
     # MANUAL PROCUREMENT AND UOM
 
-    def _get_date_planned(self):
+    def _get_date_planned(self, force_lt=None):
         self.ensure_one()
         profile = self.buffer_profile_id
         dlt = int(self.dlt)
+        if force_lt and isinstance(force_lt, (int, float)):
+            dlt = force_lt
         if profile.item_type == "distributed":
             max_proc_time = profile.distributed_reschedule_max_proc_time
         else:
@@ -1227,15 +1229,7 @@ class StockBuffer(models.Model):
         # The safety factor allows to control the date limit
         factor = self.warehouse_id.nfp_incoming_safety_factor or 1
         horizon = int(self.dlt) * factor
-        # For purchased products we use calendar days, not work days
-        if (
-            self.warehouse_id.calendar_id
-            and self.buffer_profile_id.item_type != "purchased"
-        ):
-            date_to = self.warehouse_id.wh_plan_days(datetime.now(), horizon)
-        else:
-            date_to = fields.date.today() + timedelta(days=horizon)
-        return date_to
+        return self._get_date_planned(force_lt=horizon)
 
     def _search_stock_moves_incoming_domain(self, outside_dlt=False):
         date_to = self._get_incoming_supply_date_limit()

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -401,6 +401,34 @@ class TestDdmrpCommon(common.SavepointCase):
         picking.action_confirm()
         return picking
 
+    def create_picking_in(self, product, date_move, qty):
+        picking = self.pickingModel.with_user(self.user).create(
+            {
+                "picking_type_id": self.ref("stock.picking_type_in"),
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.binA.id,
+                "scheduled_date": date_move,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Test move",
+                            "product_id": product.id,
+                            "date_expected": date_move,
+                            "date": date_move,
+                            "product_uom": product.uom_id.id,
+                            "product_uom_qty": qty,
+                            "location_id": self.supplier_location.id,
+                            "location_dest_id": self.binA.id,
+                        },
+                    )
+                ],
+            }
+        )
+        picking.action_confirm()
+        return picking
+
     def _do_picking(self, picking, date):
         """Do picking with only one move on the given date."""
         picking.action_confirm()


### PR DESCRIPTION
Since date planned is now a datetime, the limit for consider incoming moves should also be a datetime and use the
same logic.

Otherwise, a just-created incoming supply could be ignored
when rescheduled to the next day (in UTC, the problem is present
in all timezones but with an offset). This commit includes a
test case to highlight the issue.

cc @jgrandguillaume @jbaudoux 

@ForgeFlow