### PR TITLE
[14.0][FIX] ddmrp: since date planned is now a datetime, the limit to

### DIFF
--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -397,6 +397,33 @@ class TestDdmrpCommon(common.SavepointCase):
         picking.action_confirm()
         return picking
 
+    def create_picking_in(self, product, date_move, qty):
+        picking = self.pickingModel.with_user(self.user).create(
+            {
+                "picking_type_id": self.ref("stock.picking_type_in"),
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.binA.id,
+                "scheduled_date": date_move,
+                "move_lines": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": "Test move",
+                            "product_id": product.id,
+                            "date": date_move,
+                            "product_uom": product.uom_id.id,
+                            "product_uom_qty": qty,
+                            "location_id": self.supplier_location.id,
+                            "location_dest_id": self.binA.id,
+                        },
+                    )
+                ],
+            }
+        )
+        picking.action_confirm()
+        return picking
+
     def _do_picking(self, picking, date):
         """Do picking with only one move on the given date."""
         picking.action_confirm()

--- a/ddmrp/tests/test_distributed_max_proc_time.py
+++ b/ddmrp/tests/test_distributed_max_proc_time.py
@@ -1,4 +1,5 @@
-# Copyright 2020 Camptocamp
+# Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2021 ForgeFlow S.L. (http://www.forgeflow.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from freezegun import freeze_time
@@ -126,3 +127,17 @@ class TestDdmrpMaxProcTime(TestDdmrpCommon):
                 {"date": fields.Datetime.to_datetime("2020-12-11 08:30:00")},
             ],
         )
+
+    @freeze_time("2020-12-10 23:00:00")
+    def test_03_reschedule_to_next_day(self):
+        self.buffer_profile_distr.distributed_reschedule_max_proc_time = 90
+        self.warehouse.calendar_id = False
+        buffer = self.buffer_dist
+        self.assertEqual(buffer.dlt, 1)
+        self.assertEqual(buffer.incoming_dlt_qty, 0)
+        # Create a picking with date planned.
+        date_move = buffer._get_date_planned()
+        self.create_picking_in(buffer.product_id, date_move, 15.0)
+        # Picking should be in the DLT window.
+        buffer.cron_actions()
+        self.assertEqual(buffer.incoming_dlt_qty, 15.0)


### PR DESCRIPTION
consider incoming moves should also be a datetime and use the
same logic.

Otherwise, a just-created incoming supply could be ignored
when rescheduled to the next day (in UTC, the problem is present
in all timezones but with an offset). This commit includes a
test case to highlight the issue.

Forward port of https://github.com/OCA/ddmrp/pull/124.

@ForgeFlow