### PR TITLE
[13.0][FIX] ddmrp_product_replace: "considered as demand" products, also for qualified demand + ability to copy packagings

### DIFF
--- a/ddmrp_product_replace/models/stock_buffer.py
+++ b/ddmrp_product_replace/models/stock_buffer.py
@@ -149,6 +149,15 @@ class StockBuffer(models.Model):
             )
         return domain
 
+    def _search_stock_moves_qualified_demand_domain(self):
+        domain = super()._search_stock_moves_qualified_demand_domain()
+        if not self.demand_product_ids:
+            return domain
+        domain = [x for x in domain if x[0] != "product_id"] + [
+            ("product_id", "in", self.demand_product_ids.ids)
+        ]
+        return domain
+
     def action_view_buffers_replaced(self):
         action = self.env.ref("ddmrp.action_stock_buffer")
         result = action.read()[0]

--- a/ddmrp_product_replace/tests/test_product_replace.py
+++ b/ddmrp_product_replace/tests/test_product_replace.py
@@ -132,3 +132,11 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
             old_onhand, new_buffer.product_location_qty_available_not_res
         )
         self.assertNotEqual(old_incoming, new_buffer.incoming_dlt_qty)
+        # Demand:
+        self.assertIn(self.old_product, new_buffer.demand_product_ids)
+        self.assertEqual(new_buffer.qualified_demand, 0)
+        self.create_picking_out(self.old_product, datetime.today(), 11)
+        self.buffer.cron_actions()
+        self.assertEqual(self.buffer.qualified_demand, 11)
+        new_buffer.cron_actions()
+        self.assertEqual(new_buffer.qualified_demand, 11)

--- a/ddmrp_product_replace/wizards/ddmrp_product_replace.py
+++ b/ddmrp_product_replace/wizards/ddmrp_product_replace.py
@@ -55,6 +55,7 @@ class DdmrpProductReplace(models.TransientModel):
     new_product_default_code = fields.Char(string="New Product Internal Ref.")
     copy_route = fields.Boolean(string="Copy Routes")
     copy_putaway = fields.Boolean(string="Copy Put Away Strategy")
+    copy_packaging = fields.Boolean(string="Copy Packaging")
     consider_past_demand = fields.Boolean(
         string="Consider Old Product Demand",
         help="Consider Old product moves as demand for new product",
@@ -198,7 +199,16 @@ class DdmrpProductReplace(models.TransientModel):
             if putaway_ids:
                 # Copy putaway strategies
                 default_putaway = dict(product_id=self.new_product_id.id,)
-                putaway_ids.copy(default=default_putaway)
+                for pa in putaway_ids:
+                    pa.copy(default=default_putaway)
+        if self.copy_packaging:
+            packs = self.env["product.packaging"].search(
+                [("product_id", "=", primary_old.id)]
+            )
+            if packs:
+                default_packs = dict(product_id=self.new_product_id.id,)
+                for pack in packs:
+                    pack.copy(default=default_packs)
 
         if self.mode == "use_existing":
             res = self._do_replacement_use_existing()

--- a/ddmrp_product_replace/wizards/ddmrp_product_replace_view.xml
+++ b/ddmrp_product_replace/wizards/ddmrp_product_replace_view.xml
@@ -60,6 +60,7 @@
                     />
                     <field name="copy_route" />
                     <field name="copy_putaway" />
+                    <field name="copy_packaging" />
                     <field name="consider_past_demand" />
                 </group>
                 <footer>


### PR DESCRIPTION
* This way product replaced by a given buffer can affect the net flow position of the replacing buffer on the demand side as well.

* Ability to copy packagings.

@ForgeFlow