### PR TITLE
[14.0][IMP] ddmrp add used in MRP smart button

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -384,6 +384,15 @@ class StockBuffer(models.Model):
         result["domain"] = [("id", "in", mrp_production_ids.ids)]
         return result
 
+    product_type = fields.Selection(related="product_id.type", readonly=True)
+    used_in_bom_count = fields.Integer(related="product_id.used_in_bom_count")
+
+    def action_used_in_bom(self):
+        self.ensure_one()
+        action = self.env.ref("mrp.mrp_bom_form_action").read()[0]
+        action["domain"] = [("bom_line_ids.product_id", "=", self.product_id.id)]
+        return action
+
     # DDMRP SPECIFIC:
 
     @api.depends(

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -120,6 +120,19 @@
                             icon="fa-refresh"
                             type="object"
                         />
+                        <button
+                            class="oe_stat_button"
+                            name="action_used_in_bom"
+                            type="object"
+                            attrs="{'invisible':['|',('product_type', 'not in', ['product', 'consu']), ('used_in_bom_count', '=', 0)]}"
+                            icon="fa-level-up"
+                        >
+                            <field
+                                string="Used In"
+                                name="used_in_bom_count"
+                                widget="statinfo"
+                            />
+                        </button>
                     </div>
                     <widget
                         name="web_ribbon"
@@ -132,6 +145,7 @@
                             <field name="active" invisible="1" />
                             <field name="name" />
                             <field name="product_id" />
+                            <field name="product_type" invisible="1" />
                         </group>
                         <group>
                             <field

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -114,7 +114,7 @@
                             attrs="{'invisible': [('item_type', '!=', 'purchased')]}"
                         />
                         <button
-                            title="Refresh Buffer"
+                            string="Refresh Buffer"
                             name="cron_actions"
                             class="oe_stat_button"
                             icon="fa-refresh"


### PR DESCRIPTION
Add a smart button at the top of the buffer form to open the list of BOM,
same than on the product form.

Forward port of https://github.com/OCA/ddmrp/pull/149.

@ForgeFlow