### PR TITLE
[13.0] Move On-Hand status out of purchase order line

### DIFF
--- a/ddmrp/models/purchase_order.py
+++ b/ddmrp/models/purchase_order.py
@@ -11,6 +11,11 @@ class PurchaseOrder(models.Model):
 
     ddmrp_comment = fields.Text(string="Follow-up Notes")
 
+    def action_ddmrp_line_details(self):
+        action = self.env.ref("ddmrp.po_line_execution_action").read()[0]
+        action["domain"] = [("id", "in", self.order_line.ids)]
+        return action
+
 
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"

--- a/ddmrp/views/purchase_order_view.xml
+++ b/ddmrp/views/purchase_order_view.xml
@@ -7,17 +7,15 @@
         <field name="model">purchase.order</field>
         <field name="inherit_id" ref="purchase.purchase_order_form" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//field[@name='order_line']//field[@name='date_planned']"
-                position="after"
-            >
-                <field name="buffer_ids" invisible="1" />
-                <field name="execution_priority_level" invisible="1" />
-                <field
-                    name="on_hand_percent"
-                    options='{"buffer_ids": "buffer_ids", "color_from": "execution_priority_level"}'
+            <div name="button_box" position="inside">
+                <button
+                    name="action_ddmrp_line_details"
+                    type="object"
+                    string="Line On-Hand Status"
+                    class="oe_stat_button"
+                    icon="fa-tasks"
                 />
-            </xpath>
+            </div>
             <xpath
                 expr="//page[@name='purchase_delivery_invoice']/group/group"
                 position="inside"


### PR DESCRIPTION
In the purchase order form view, the on hand status is visible in the
ordered lines tree view.
This information slows down the load of every large purchase order when
this information is not always usefull.

To improve on this. This change removes the on hand status from the
purchase order form.
And adds a smart button on the from to visualize this information.