### PR TITLE
[14.0][ADD] Packaging to make procurement wizard

### DIFF
--- a/ddmrp_packaging/__init__.py
+++ b/ddmrp_packaging/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/ddmrp_packaging/__manifest__.py
+++ b/ddmrp_packaging/__manifest__.py
@@ -9,7 +9,7 @@
     "website": "https://github.com/OCA/ddmrp",
     "category": "Warehouse Management",
     "depends": ["ddmrp"],
-    "data": ["views/stock_buffer_view.xml"],
+    "data": ["views/stock_buffer_view.xml", "wizards/make_procurement_buffer_view.xml"],
     "license": "LGPL-3",
     "installable": True,
     "auto_install": False,

--- a/ddmrp_packaging/wizards/__init__.py
+++ b/ddmrp_packaging/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import make_procurement_buffer

--- a/ddmrp_packaging/wizards/make_procurement_buffer.py
+++ b/ddmrp_packaging/wizards/make_procurement_buffer.py
@@ -1,0 +1,24 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+
+from odoo import api, fields, models
+
+
+class MakeProcurementBufferItem(models.TransientModel):
+    _inherit = "make.procurement.buffer.item"
+
+    packaging_id = fields.Many2one(
+        string="Package",
+        comodel_name="product.packaging",
+    )
+    packaging_qty = fields.Integer(string="Package Qty")
+
+    @api.onchange("packaging_qty", "packaging_id")
+    def onchange_packaging(self):
+        if not self.packaging_id:
+            self.packaging_qty = False
+            return
+        if not self.packaging_qty:
+            self.packaging_qty = 1
+        self.qty = self.packaging_id.qty * self.packaging_qty

--- a/ddmrp_packaging/wizards/make_procurement_buffer_view.xml
+++ b/ddmrp_packaging/wizards/make_procurement_buffer_view.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="view_make_procurement_buffer_wizard" model="ir.ui.view">
+        <field name="name">Request Procurement Packaging</field>
+        <field name="inherit_id" ref="ddmrp.view_make_procurement_buffer_wizard" />
+        <field name="model">make.procurement.buffer</field>
+        <field name="arch" type="xml">
+            <field name="recommended_qty" position="after">
+                <field name="packaging_id" domain="[('product_id', '=', product_id)]" />
+                <field name="packaging_qty" />
+            </field>
+        </field>
+    </record>
+    <record id="view_make_procure_without_security" model="ir.ui.view">
+        <field name="name">Request Procurement Packaging</field>
+        <field name="model">make.procurement.buffer</field>
+        <field name="inherit_id" ref="ddmrp.view_make_procure_without_security" />
+        <field name="arch" type="xml">
+            <field name="packaging_id" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="packaging_qty" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
On the wizard to make a procurement from a stock.buffer.
This change allows to select a packaging and a quantity of that
specific packaging, to automatically fill the quantity to procure.

Forward port https://github.com/OCA/ddmrp/pull/162/.

@ForgeFlow