### PR TITLE
[14.0][IMP] ddmrp: Add yearly consumption button stock.buffer

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -183,6 +183,16 @@ class StockBuffer(models.Model):
         result["domain"] = [("id", "in", purchase_ids.ids)]
         return result
 
+    def action_view_yearly_consumption(self):
+        action = self.env.ref("ddmrp.stock_move_year_consumption_action")
+        result = action.read()[0]
+        result["domain"] = [
+            ("product_id", "=", self.product_id.id),
+            ("state", "=", "done"),
+            ("location_dest_id.usage", "in", ["customer", "production"]),
+        ]
+        return result
+
     @api.constrains("product_id")
     def _check_product_uom(self):
         if any(

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -186,11 +186,14 @@ class StockBuffer(models.Model):
     def action_view_yearly_consumption(self):
         action = self.env.ref("ddmrp.stock_move_year_consumption_action")
         result = action.read()[0]
-        result["domain"] = [
-            ("product_id", "=", self.product_id.id),
-            ("state", "=", "done"),
-            ("location_dest_id.usage", "in", ["customer", "production"]),
-        ]
+        locations = self.env["stock.location"].search(
+            [("id", "child_of", [self.location_id.id])]
+        )
+        date_to = fields.Date.today()
+        # We take last five years, even though they will be initially
+        # filtered in the action to show only last year.
+        date_from = date_to - timedelta(days=5 * 365)
+        result["domain"] = self._past_moves_domain(date_from, date_to, locations)
         return result
 
     @api.constrains("product_id")

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -962,3 +962,9 @@ class TestDdmrp(TestDdmrpCommon):
         self.product_c_blue.toggle_active()
         self.assertTrue(self.buffer_c_blue.active)
         self.assertTrue(self.product_c_blue.active)
+
+    def test_43_test_button_actions(self):
+        """Quick and simple tests for secondary actions."""
+        # Consumption:
+        action = self.buffer_a.action_view_yearly_consumption()
+        self.assertTrue(isinstance(action, dict))

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -104,6 +104,13 @@
                     <div class="oe_button_box" name="button_box">
                         <button
                             type="object"
+                            name="action_view_yearly_consumption"
+                            class="oe_stat_button"
+                            string="Consumption"
+                            icon="fa-fire"
+                        />
+                        <button
+                            type="object"
                             name="action_view_mrp_productions"
                             class="oe_stat_button"
                             string="Manufacturing Orders"

--- a/ddmrp/views/stock_move_views.xml
+++ b/ddmrp/views/stock_move_views.xml
@@ -27,4 +27,25 @@
             </field>
         </field>
     </record>
+    <record id="view_move_consumption_pivot" model="ir.ui.view">
+        <field name="name">stock.move.consumption.pivot</field>
+        <field name="model">stock.move</field>
+        <field name="arch" type="xml">
+            <pivot string="Stock Moves Yearly Consumption">
+                <field name="date" interval="month" type="row" />
+                <field name="location_dest_id" type="col" />
+                <field name="product_uom_qty" type="measure" />
+            </pivot>
+        </field>
+    </record>
+    <record id="stock_move_year_consumption_action" model="ir.actions.act_window">
+        <field name="name">Stock Move Last Year Consumption</field>
+        <field name="res_model">stock.move</field>
+        <field name="view_id" ref="ddmrp.view_move_consumption_pivot" />
+        <field
+            name="context"
+        >{"time_ranges": {"field": "date", "range": "last_365_days"}}</field>
+        <field name="domain" />
+        <field name="view_mode">pivot</field>
+    </record>
 </odoo>


### PR DESCRIPTION
Forward port of https://github.com/OCA/ddmrp/pull/150 and https://github.com/OCA/ddmrp/pull/163.

Also, include a small test

@ForgeFlow