### PR TITLE
[FIX] ddmrp: add bokeh dependency, make pre-commit happy

### DIFF
--- a/ddmrp/__manifest__.py
+++ b/ddmrp/__manifest__.py
@@ -12,6 +12,7 @@
     "maintainers": ["JordiBForgeFlow", "LoisRForgeFlow"],
     "website": "https://github.com/OCA/ddmrp",
     "category": "Warehouse",
+    "external_dependencies": {"python": ["bokeh==2.3.1"]},
     "depends": [
         "purchase_stock",
         "mrp_bom_location",

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 from odoo.exceptions import ValidationError
 
-from odoo.addons.ddmrp.tests.common import TestDdmrpCommon
+from .common import TestDdmrpCommon
 
 
 class TestDdmrp(TestDdmrpCommon):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # generated from manifests external_dependencies
+bokeh==2.3.1
 pandas>=0.25.3


### PR DESCRIPTION
This is to explicitly have `bokeh` as external dependency and to make pre-commit green.