### PR TITLE
[13.0][FIX] Disable unarchiving buffer on product activation

### DIFF
--- a/ddmrp/models/product_product.py
+++ b/ddmrp/models/product_product.py
@@ -13,14 +13,9 @@ class Product(models.Model):
 
     def write(self, values):
         res = super().write(values)
-        if "active" in values:
-            buffers = self.env["stock.buffer"].search(
-                [
-                    ("product_id", "in", self.ids),
-                    "|",
-                    ("active", "=", True),
-                    ("active", "=", False),
-                ]
+        if values.get("active") is False:
+            buffers = (
+                self.env["stock.buffer"].sudo().search([("product_id", "in", self.ids)])
             )
-            buffers.write({"active": values.get("active")})
+            buffers.write({"active": False})
         return res


### PR DESCRIPTION
Having the stock buffer automatically unarchived when the state of a
product changes is dangerous because it can lead to product being
ordered again when it should not anymore.

The issue encountered seemed to be related to how Odoo handles product
variant. And some changes in the product attribute line of a product
would call a write on the active field of related products variant.

An improvement that could be added (maybe coming soon) is to have on
the product form the information of existing archived stock buffers.