### PR TITLE
[13.0][FIX] ddmrp_product_replace: compute incoming qty

### DIFF
--- a/ddmrp_product_replace/models/stock_buffer.py
+++ b/ddmrp_product_replace/models/stock_buffer.py
@@ -130,12 +130,18 @@ class StockBuffer(models.Model):
             if not (rec.use_replacement_for_buffer_status and rec.replacement_for_ids):
                 continue
             for buffer in rec.replacement_for_ids:
-                replacements_qty = buffer.product_uom._compute_quantity(
+                # Update 'incoming_location_qty'
+                replacements_incoming_qty = buffer.product_uom._compute_quantity(
+                    buffer.incoming_location_qty, rec.product_uom, round=False,
+                )
+                rec.incoming_location_qty += replacements_incoming_qty
+                # Update 'product_location_qty_available_not_res'
+                replacements_qty_not_res = buffer.product_uom._compute_quantity(
                     buffer.product_location_qty_available_not_res,
                     rec.product_uom,
                     round=False,
                 )
-                rec.product_location_qty_available_not_res += replacements_qty
+                rec.product_location_qty_available_not_res += replacements_qty_not_res
         return res
 
     def _search_stock_moves_incoming_domain(self, outside_dlt=False):

--- a/ddmrp_product_replace/tests/test_product_replace.py
+++ b/ddmrp_product_replace/tests/test_product_replace.py
@@ -89,8 +89,10 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
         self.assertEqual(len(self.buffer.demand_product_ids), 0)
         old_onhand = self.buffer.product_location_qty_available_not_res
         self.assertEqual(old_onhand, -60.0)
-        old_incoming = self.buffer.incoming_dlt_qty
-        self.assertEqual(old_incoming, 30.0)
+        old_incoming_dlt_qty = self.buffer.incoming_dlt_qty
+        self.assertEqual(old_incoming_dlt_qty, 30.0)
+        old_incoming_qty = self.buffer.incoming_location_qty
+        self.assertEqual(old_incoming_qty, 30.0)
         wiz = self.env["ddmrp.product.replace"].create(
             {
                 "mode": "new_buffer",
@@ -124,14 +126,16 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
         # Check buffer values:
         self.buffer.cron_actions()
         self.assertEqual(old_onhand, new_buffer.product_location_qty_available_not_res)
-        self.assertEqual(old_incoming, new_buffer.incoming_dlt_qty)
+        self.assertEqual(old_incoming_dlt_qty, new_buffer.incoming_dlt_qty)
+        self.assertEqual(old_incoming_qty, new_buffer.incoming_location_qty)
         new_buffer.invalidate_cache()
         new_buffer.use_replacement_for_buffer_status = False
         new_buffer.cron_actions()
         self.assertNotEqual(
             old_onhand, new_buffer.product_location_qty_available_not_res
         )
-        self.assertNotEqual(old_incoming, new_buffer.incoming_dlt_qty)
+        self.assertNotEqual(old_incoming_dlt_qty, new_buffer.incoming_dlt_qty)
+        self.assertNotEqual(old_incoming_qty, new_buffer.incoming_location_qty)
         # Demand:
         self.assertIn(self.old_product, new_buffer.demand_product_ids)
         self.assertEqual(new_buffer.qualified_demand, 0)


### PR DESCRIPTION
Take into account product replacements when the incoming qty is computed.

Ref. 3056