### PR TITLE
[14.0] Fix quantity_in_progress computation

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -166,6 +166,8 @@ class StockBuffer(models.Model):
         )
         for poline in polines:
             for buffer in poline.buffer_ids:
+                if buffer.id not in self.ids:
+                    continue
                 res[buffer.id] += poline.product_uom._compute_quantity(
                     poline.product_qty, buffer.product_uom, round=False
                 )


### PR DESCRIPTION
If a purchase order line is related to multiple buffers but not all of
those buffer are included in `self` then the computation crash.