### PR TITLE
[14.0][FIX] ddmrp*: remove direct read of client action

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -172,20 +172,20 @@ class StockBuffer(models.Model):
         return res
 
     def action_view_purchase(self):
-        action = self.env.ref("purchase.purchase_rfq")
-        result = action.read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id("purchase.purchase_rfq")
         # Remove the context since the action basically display RFQ and not PO.
-        result["context"] = {}
+        action["context"] = {}
         order_line_ids = self.env["purchase.order.line"].search(
             [("buffer_ids", "in", self.ids)]
         )
         purchase_ids = order_line_ids.mapped("order_id")
-        result["domain"] = [("id", "in", purchase_ids.ids)]
-        return result
+        action["domain"] = [("id", "in", purchase_ids.ids)]
+        return action
 
     def action_view_yearly_consumption(self):
-        action = self.env.ref("ddmrp.stock_move_year_consumption_action")
-        result = action.read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "ddmrp.stock_move_year_consumption_action"
+        )
         locations = self.env["stock.location"].search(
             [("id", "child_of", [self.location_id.id])]
         )
@@ -193,8 +193,8 @@ class StockBuffer(models.Model):
         # We take last five years, even though they will be initially
         # filtered in the action to show only last year.
         date_from = date_to - timedelta(days=5 * 365)
-        result["domain"] = self._past_moves_domain(date_from, date_to, locations)
-        return result
+        action["domain"] = self._past_moves_domain(date_from, date_to, locations)
+        return action
 
     @api.constrains("product_id")
     def _check_product_uom(self):
@@ -388,8 +388,7 @@ class StockBuffer(models.Model):
     # MRP LINK:
 
     def action_view_mrp_productions(self):
-        action = self.env.ref("mrp.mrp_production_action")
-        result = action.read()[0]
+        result = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_production_action")
         result["context"] = {}
         mrp_production_ids = self.env["mrp.production"].search(
             [("buffer_id", "=", self.id)]
@@ -402,7 +401,7 @@ class StockBuffer(models.Model):
 
     def action_used_in_bom(self):
         self.ensure_one()
-        action = self.env.ref("mrp.mrp_bom_form_action").read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_form_action")
         action["domain"] = [("bom_line_ids.product_id", "=", self.product_id.id)]
         return action
 
@@ -1595,23 +1594,24 @@ class StockBuffer(models.Model):
             )
             moves = self._search_stock_moves_incoming(outside_dlt=True)
             pos = pols.mapped("order_id") + moves.mapped("purchase_line_id.order_id")
-            action = self.env.ref("purchase.purchase_rfq")
-            result = action.read()[0]
+            result = self.env["ir.actions.actions"]._for_xml_id("purchase.purchase_rfq")
             # Remove the context since the action display RFQ and not PO.
             result["context"] = {}
             result["domain"] = [("id", "in", pos.ids)]
         elif self.item_type == "manufactured":
             moves = self._search_stock_moves_incoming(outside_dlt=True)
             mos = moves.mapped("production_id")
-            action = self.env.ref("mrp.mrp_production_action")
-            result = action.read()[0]
+            result = self.env["ir.actions.actions"]._for_xml_id(
+                "mrp.mrp_production_action"
+            )
             result["context"] = {}
             result["domain"] = [("id", "in", mos.ids)]
         else:
             moves = self._search_stock_moves_incoming(outside_dlt=True)
             picks = moves.mapped("picking_id")
-            action = self.env.ref("stock.action_picking_tree_all")
-            result = action.read()[0]
+            result = self.env["ir.actions.actions"]._for_xml_id(
+                "stock.action_picking_tree_all"
+            )
             result["context"] = {}
             result["domain"] = [("id", "in", picks.ids)]
         return result

--- a/ddmrp/models/stock_picking.py
+++ b/ddmrp/models/stock_picking.py
@@ -14,7 +14,7 @@ class StockPickgin(models.Model):
             ("product_id", "in", self.mapped("move_lines.product_id.id")),
             ("company_id", "=", self.company_id.id),
         ]
-        action = self.env.ref("ddmrp.action_stock_buffer").read()[0]
+        action = self.env["ir.actions.actions"]._for_xml_id("ddmrp.action_stock_buffer")
         action["domain"] = domain
         action["context"] = {"search_default_procure_recommended": 1}
         return action

--- a/ddmrp_product_replace/models/stock_buffer.py
+++ b/ddmrp_product_replace/models/stock_buffer.py
@@ -179,8 +179,7 @@ class StockBuffer(models.Model):
         return domain
 
     def action_view_buffers_replaced(self):
-        action = self.env.ref("ddmrp.action_stock_buffer")
-        result = action.read()[0]
+        result = self.env["ir.actions.actions"]._for_xml_id("ddmrp.action_stock_buffer")
         result["name"] = _("Buffers Replaced")
         result["domain"] = [("id", "in", self.replacement_for_ids.ids)]
         return result


### PR DESCRIPTION
due to refactoring security rules direct access to client action is restricted, all access should be done through the method 
related
https://github.com/odoo/odoo/commit/de4213b771f641cbc218ebb1f759b09e064100bf#diff-e275aaa5de11da2815c2f0cc18bc046f967df5e4eba94999ee55ffe8926c87bd