### PR TITLE
[13.0][IMP] ddmrp: add index on 'distributed_source_location_id'

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1025,6 +1025,7 @@ class StockBuffer(models.Model):
         string="Replenishment Location",
         comodel_name="stock.location",
         readonly=True,
+        index=True,
         help="Source location from where goods will be replenished. "
         "Computed when buffer is refreshed from following the Stock Rules.",
     )


### PR DESCRIPTION
We spotted the following query taking a huge amount of time to execute (~15s) on one of our customer DB:
```sql
SELECT "stock_buffer".id FROM "stock_buffer" WHERE ("stock_buffer"."distributed_source_location_id" IS NOT NULL) ORDER BY "stock_buffer"."id"
```

The filter on `distributed_source_location_qty` is using a search method querying the `distributed_source_location_id` field having no index, so this commit is adding one.