### PR TITLE
[14.0] Add ddmrp_packaging_product_replace

### DIFF
--- a/ddmrp_packaging_product_replace/__init__.py
+++ b/ddmrp_packaging_product_replace/__init__.py
@@ -1,0 +1,1 @@
+from . import wizards

--- a/ddmrp_packaging_product_replace/__manifest__.py
+++ b/ddmrp_packaging_product_replace/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "DDMRP Packaging Product Replace",
+    "summary": "Glue module for DDMRP packaging and product replace",
+    "version": "14.0.1.0.0",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/ddmrp",
+    "category": "Warehouse Management",
+    "depends": ["ddmrp_product_replace", "ddmrp_packaging"],
+    "license": "LGPL-3",
+    "installable": True,
+    "auto_install": True,
+}

--- a/ddmrp_packaging_product_replace/readme/CONTRIBUTORS.rst
+++ b/ddmrp_packaging_product_replace/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/ddmrp_packaging_product_replace/readme/DESCRIPTION.rst
+++ b/ddmrp_packaging_product_replace/readme/DESCRIPTION.rst
@@ -1,0 +1,7 @@
+This is a glue module between `ddmrp_packaging` and `ddmrp_product_replace`.
+It disable the copy of the packaging information when using the product
+replacement wizard.
+Without it the new stock buffer created have the packaging of the old product
+set on them and the constraint `_check_product_packaging` raises an error.
+
+Strangely, this is not happening with Odoo 13 ?

--- a/ddmrp_packaging_product_replace/tests/__init__.py
+++ b/ddmrp_packaging_product_replace/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_product_replace_packaging

--- a/ddmrp_packaging_product_replace/tests/test_product_replace_packaging.py
+++ b/ddmrp_packaging_product_replace/tests/test_product_replace_packaging.py
@@ -1,0 +1,35 @@
+from odoo.addons.ddmrp_product_replace.tests.test_product_replace import (
+    TestDDMRPProductReplace,
+)
+
+
+class TestDDMRPPackagingProductReplace(TestDDMRPProductReplace):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.replacement_product = cls.env.ref("ddmrp.product_product_rm02")
+        cls.packaging1 = cls.env["product.packaging"].create(
+            {"name": "Packaging Test 1", "product_id": cls.buffer.product_id.id}
+        )
+        cls.buffer.packaging_id = cls.packaging1.id
+
+    def test_product_replace_packaging(self):
+        """Check replacement product with packaging on buffers."""
+        wiz = self.env["ddmrp.product.replace"].create(
+            {
+                "mode": "new_buffer",
+                "old_product_ids": [(6, 0, self.buffer.product_id.ids)],
+                "use_existing": "existing",
+                "new_product_id": self.replacement_product.id,
+            }
+        )
+        self.assertEqual(wiz.buffer_ids, self.buffer)
+        self.assertFalse(wiz.is_already_replaced)
+        res = wiz.button_validate()
+        new_buffer_ids = res.get("domain")[0][2]
+        model = res.get("res_model")
+        self.assertEqual(model, "stock.buffer")
+        new_buffer = self.bufferModel.browse(new_buffer_ids)
+        self.assertEqual(len(new_buffer), 1)
+        self.assertNotEqual(self.buffer.id, new_buffer.id)
+        self.assertFalse(new_buffer.packaging_id)

--- a/ddmrp_packaging_product_replace/wizards/__init__.py
+++ b/ddmrp_packaging_product_replace/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import ddmrp_product_replace

--- a/ddmrp_packaging_product_replace/wizards/ddmrp_product_replace.py
+++ b/ddmrp_packaging_product_replace/wizards/ddmrp_product_replace.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+
+
+class DdmrpProductReplace(models.TransientModel):
+    _inherit = "ddmrp.product.replace"
+
+    def _get_new_buffer_default_value(self, replaced_buffer):
+        vals = super()._get_new_buffer_default_value(replaced_buffer)
+        vals["packaging_id"] = False
+        return vals

--- a/ddmrp_product_replace/wizards/ddmrp_product_replace.py
+++ b/ddmrp_product_replace/wizards/ddmrp_product_replace.py
@@ -123,15 +123,18 @@ class DdmrpProductReplace(models.TransientModel):
             "type": "ir.actions.act_window",
         }
 
+    def _get_new_buffer_default_value(self, replaced_buffer):
+        return dict(
+            product_id=self.new_product_id.id,
+            auto_procure=False,
+            demand_product_ids=False,
+        )
+
     def _do_replacement_new_buffer(self):
         primary_old = self.primary_old_product_id
         new_buffers = self.env["stock.buffer"]
         for replaced in self.buffer_ids.filtered(lambda b: b.product_id == primary_old):
-            default = dict(
-                product_id=self.new_product_id.id,
-                auto_procure=False,
-                demand_product_ids=False,
-            )
+            default = self._get_new_buffer_default_value(replaced)
             replacing = replaced.copy(default=default)
             replaced.write({"replaced_by_id": replacing.id})
             new_buffers |= replacing

--- a/setup/ddmrp_packaging_product_replace/odoo/addons/ddmrp_packaging_product_replace
+++ b/setup/ddmrp_packaging_product_replace/odoo/addons/ddmrp_packaging_product_replace
@@ -1,0 +1,1 @@
+../../../../ddmrp_packaging_product_replace

--- a/setup/ddmrp_packaging_product_replace/setup.py
+++ b/setup/ddmrp_packaging_product_replace/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
There seems to be a different outcome when doing a product replacement
with packaging set on the related stock buffers between v13 and v14. In
v13 the following test passes.
But on v14 the new stock buffer created has the packaging of the old
product set on them and the constraint `_check_product_packaging` raises
an error.