### PR TITLE
[14.0] Add ddmrp_purchase_hide_onhand_status

### DIFF
--- a/ddmrp/wizards/res_config_settings.py
+++ b/ddmrp/wizards/res_config_settings.py
@@ -29,6 +29,9 @@ class ResConfigSettings(models.TransientModel):
     module_ddmrp_chatter = fields.Boolean(
         string="Chatter in Stock Buffers",
     )
+    module_ddmrp_purchase_hide_onhand_status = fields.Boolean(
+        string="Hide Purchase On-Hand Status",
+    )
     ddmrp_auto_update_nfp = fields.Boolean(
         related="company_id.ddmrp_auto_update_nfp", readonly=False
     )

--- a/ddmrp/wizards/res_config_settings_views.xml
+++ b/ddmrp/wizards/res_config_settings_views.xml
@@ -98,6 +98,19 @@
                         </div>
                         <div class="col-xs-12 col-md-6 o_setting_box">
                             <div class="o_setting_left_pane">
+                                <field
+                                    name="module_ddmrp_purchase_hide_onhand_status"
+                                />
+                            </div>
+                            <div class="o_setting_right_pane">
+                                <label for="module_ddmrp_purchase_hide_onhand_status" />
+                                <div class="text-muted">
+                                    Hides on-hand status from purchase order line.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xs-12 col-md-6 o_setting_box">
+                            <div class="o_setting_left_pane">
                                 <field name="module_ddmrp_warning" />
                             </div>
                             <div class="o_setting_right_pane">

--- a/ddmrp_purchase_hide_onhand_status/__init__.py
+++ b/ddmrp_purchase_hide_onhand_status/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/ddmrp_purchase_hide_onhand_status/__manifest__.py
+++ b/ddmrp_purchase_hide_onhand_status/__manifest__.py
@@ -1,0 +1,19 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+{
+    "name": "DDMRP Purchase Hide On-Hand Status",
+    "version": "14.0.1.0.0",
+    "summary": "Replace purchase onhand status with smart button.",
+    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "development_status": "Beta",
+    "maintainers": ["TDu"],
+    "website": "https://github.com/OCA/ddmrp",
+    "category": "Warehouse Management",
+    "depends": ["ddmrp"],
+    "data": [
+        "views/purchase_order_view.xml",
+    ],
+    "license": "LGPL-3",
+    "installable": True,
+}

--- a/ddmrp_purchase_hide_onhand_status/models/__init__.py
+++ b/ddmrp_purchase_hide_onhand_status/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order

--- a/ddmrp_purchase_hide_onhand_status/models/purchase_order.py
+++ b/ddmrp_purchase_hide_onhand_status/models/purchase_order.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+
+from odoo import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def action_ddmrp_line_details(self):
+        action = self.env["ir.actions.actions"]._for_xml_id(
+            "ddmrp.po_line_execution_action"
+        )
+        action["domain"] = [("id", "in", self.order_line.ids)]
+        return action

--- a/ddmrp_purchase_hide_onhand_status/readme/CONTRIBUTORS.rst
+++ b/ddmrp_purchase_hide_onhand_status/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Thierry Ducrest <thierry.ducrest@camptocamp.com>

--- a/ddmrp_purchase_hide_onhand_status/readme/DESCRIPTION.rst
+++ b/ddmrp_purchase_hide_onhand_status/readme/DESCRIPTION.rst
@@ -1,0 +1,5 @@
+This DDMRP module removes on the purchase order form the On-Hand status
+information in the list of purchase line. This can help on loading time for
+large purchase order.
+A smart button is added on the form `Line On-Hand status` to visualize the
+removed information.

--- a/ddmrp_purchase_hide_onhand_status/tests/__init__.py
+++ b/ddmrp_purchase_hide_onhand_status/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ddmrp_purchase_hide_onhand_status

--- a/ddmrp_purchase_hide_onhand_status/tests/test_ddmrp_purchase_hide_onhand_status.py
+++ b/ddmrp_purchase_hide_onhand_status/tests/test_ddmrp_purchase_hide_onhand_status.py
@@ -1,0 +1,15 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import SavepointCase
+
+
+class TestDDMRPPurchaseHideOnhandStatus(SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.po = cls.env.ref("purchase.purchase_order_1")
+
+    def test_ddmrp_purchase_hide_onhand_status(self):
+        value = self.po.action_ddmrp_line_details()
+        self.assertTrue(value)

--- a/ddmrp_purchase_hide_onhand_status/views/purchase_order_view.xml
+++ b/ddmrp_purchase_hide_onhand_status/views/purchase_order_view.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<!-- pylint:disable=dangerous-view-replace-wo-priority -->
+<!-- Using replace, because hidding the fields would still -->
+<!-- cause them to be loaded by the system. -->
+<!-- And that would be conterintuitive for performance. -->
+<odoo>
+    <record id="purchase_order_form" model="ir.ui.view">
+        <field
+            name="name"
+        >purchase.order.form - ddmrp purchase hide onhand status</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="ddmrp.purchase_order_form" />
+        <field name="arch" type="xml">
+          <xpath
+                expr="//field[@name='order_line']//field[@name='buffer_ids']"
+                position="replace"
+            />
+          <xpath
+                expr="//field[@name='order_line']//field[@name='execution_priority_level']"
+                position="replace"
+            />
+          <xpath
+                expr="//field[@name='order_line']//field[@name='on_hand_percent']"
+                position="replace"
+            />
+          <div name="button_box" position="inside">
+            <button
+                    name="action_ddmrp_line_details"
+                    type="object"
+                    string="Line On-Hand Status"
+                    class="oe_stat_button"
+                    icon="fa-tasks"
+                />
+          </div>
+        </field>
+    </record>
+</odoo>

--- a/setup/ddmrp_purchase_hide_onhand_status/odoo/addons/ddmrp_purchase_hide_onhand_status
+++ b/setup/ddmrp_purchase_hide_onhand_status/odoo/addons/ddmrp_purchase_hide_onhand_status
@@ -1,0 +1,1 @@
+../../../../ddmrp_purchase_hide_onhand_status

--- a/setup/ddmrp_purchase_hide_onhand_status/setup.py
+++ b/setup/ddmrp_purchase_hide_onhand_status/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
This DDMRP module removes on the purchase order form the On-Hand status
information in the list of purchase line. This can help on loading time for
large purchase order.
A smart button is added on the form `Line On-Hand status` to visualize the
removed information.