### PR TITLE
[14.0][Fix] planning chart display in ddmrp_history

### DIFF
--- a/ddmrp_history/models/stock_buffer.py
+++ b/ddmrp_history/models/stock_buffer.py
@@ -108,11 +108,14 @@ class StockBuffer(models.Model):
             tops = [
                 data[categories[0]][i] + data[categories[1]][i] + data[categories[2]][i]
                 for i in range(N)
-            ]
+            ] + [max(data["on_hand_position"]), max(data["net_flow_position"])]
             top_y = max(tops)
+            min_y = min(
+                [0, min(data["on_hand_position"]), min(data["net_flow_position"])]
+            )
             p = figure(
                 x_range=(dates[0], dates[-1]),
-                y_range=(0, top_y),
+                y_range=(min_y, top_y),
                 x_axis_type="datetime",
             )
             p.sizing_mode = "stretch_both"

--- a/ddmrp_history/models/stock_buffer.py
+++ b/ddmrp_history/models/stock_buffer.py
@@ -244,7 +244,7 @@ class StockBuffer(models.Model):
             top_y = max(tops)
             p = figure(
                 x_range=(dates[0], dates[-1]),
-                y_range=(start_stack, top_y),
+                y_range=(start_stack, top_y or 100),
                 x_axis_type="datetime",
             )
             p.sizing_mode = "stretch_both"


### PR DESCRIPTION
When displaying some buffers there is an error coming up from the
bokeh library:

    Error: invalid bbox {left: NaN, top: NaN, right: NaN, bottom: NaN}

And the planning chart would not be displayed.

Looking at the data used for generating the chart, the green, yellow and red are
populated with zeros. This lead to an y axis of 0 to 0.

But also the two positions data (net flow and on hand) were sometimes populated
with negative values.

This fixed the problem but maybe those values generated by the buffer were
already incorrect.