### PR TITLE
[13.0] ddmrp: auto_procure when stock increases at replenishment location

### DIFF
--- a/ddmrp/README.rst
+++ b/ddmrp/README.rst
@@ -292,6 +292,7 @@ Contributors
 * Lois Rilo Antelo <lois.rilo@forgeflow.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1610,6 +1610,7 @@ class StockBuffer(models.Model):
             self._calc_qualified_demand()
         if not only_nfp or only_nfp == "in":
             self._calc_incoming_dlt_qty()
+        old_net_flow_position = self.net_flow_position
         self._calc_net_flow_position()
         self._calc_distributed_source_location()
         self._calc_planning_priority()
@@ -1619,7 +1620,22 @@ class StockBuffer(models.Model):
         if not only_nfp:
             # re-compoute red to force in cascade the recalculation of zones.
             self._compute_red_zone()
-        self.do_auto_procure()
+        rounding = self.procure_uom_id.rounding or self.product_uom.rounding
+        # In case of in/out moves change, only trigger auto procure when the
+        # need is increased (e.g. in move canceled or out move created).
+        # When an in move is created, it must not trigger an auto procure as
+        # this cron_actions is called before distributed_source_location_qty is
+        # updated (quants reservation at source location is performed after the
+        # in move creation).
+        if not only_nfp or (
+            float_compare(
+                old_net_flow_position,
+                self.net_flow_position,
+                precision_rounding=rounding,
+            )
+            > 0
+        ):
+            self.do_auto_procure()
         return True
 
     @api.model

--- a/ddmrp/readme/CONTRIBUTORS.rst
+++ b/ddmrp/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Lois Rilo Antelo <lois.rilo@forgeflow.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -470,6 +470,6 @@ class TestDdmrpCommon(common.SavepointCase):
 
     def _do_move(self, move, date):
         move._action_confirm()
-        move.move_line_ids.quantity_done = move.move_line_ids.product_uom_qty
+        move.quantity_done = move.product_uom_qty
         move._action_done()
         move.date = date

--- a/ddmrp/tests/test_ddmrp_distributed_source_location.py
+++ b/ddmrp/tests/test_ddmrp_distributed_source_location.py
@@ -1,5 +1,8 @@
 # Copyright 2020 Camptocamp (https://www.camptocamp.com)
+# Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from datetime import datetime
 
 from .common import TestDdmrpCommon
 
@@ -129,6 +132,43 @@ class TestDdmrpDistributedSourceLocation(TestDdmrpCommon):
                     "qty": 4000,
                 }
             ],
+        )
+
+    def test_distributed_source_limit_replenish_auto_procure(self):
+        """ When the buffer is in auto procure with a recommended qty, test it
+        triggers a replenishment when the qty increases at the replenishment
+        source location
+        """
+        self.assertEqual(self.buffer_dist.distributed_source_location_qty, 0)
+        self.main_company.ddmrp_auto_update_nfp = True
+        self.buffer_dist.auto_procure = True
+        self.buffer_dist.auto_procure_option = "standard"
+        date_move = datetime.today()
+        initial_recommended_qty = 5000
+        self.create_picking_out(
+            self.product_c_orange, date_move, initial_recommended_qty
+        )
+        self.assertEqual(
+            self.buffer_dist.procure_recommended_qty, initial_recommended_qty
+        )
+
+        # Increase stock at replenishment location. That should trigger a
+        # replenishment move
+        source_location_qty = 2000
+        move = self.moveModel.with_user(self.user).create(
+            {
+                "name": "Test inventory move",
+                "product_id": self.product_c_orange.id,
+                "product_uom": self.product_c_orange.uom_id.id,
+                "product_uom_qty": source_location_qty,
+                "location_id": self.inventory_location.id,
+                "location_dest_id": self.replenish_location.id,
+            },
+        )
+        self._do_move(move, move.date)
+        self.assertEqual(
+            self.buffer_dist.procure_recommended_qty,
+            initial_recommended_qty - source_location_qty,
         )
 
     def test_distributed_source_limit_replenish_with_batch_limit_max(self):


### PR DESCRIPTION
In auto procure, if the profile is configured in distributed with a limit to free qty, it is possible that not all the required quantity is
replenished. When the quantity increases at the replenishment location, a new auto procurement should be triggered.

cc @sebalix @LoisRForgeFlow @jgrandguillaume 