### PR TITLE
[14.0][FW] [FIX] ddmrp: auto_procure when stock increases at replenishment location

### DIFF
--- a/ddmrp/README.rst
+++ b/ddmrp/README.rst
@@ -292,6 +292,7 @@ Contributors
 * Lois Rilo Antelo <lois.rilo@forgeflow.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 
 Other credits
 ~~~~~~~~~~~~~

--- a/ddmrp/models/stock_move.py
+++ b/ddmrp/models/stock_move.py
@@ -1,4 +1,5 @@
 # Copyright 2019-20 ForgeFlow S.L. (http://www.forgeflow.com)
+# Copyright 2022 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo import api, fields, models
@@ -35,6 +36,10 @@ class StockMove(models.Model):
                     lambda m: m.state
                     in ("confirmed", "partially_available", "assigned")
                 )._update_ddmrp_nfp()
+            if vals.get("state") == "done":
+                in_buffers = self._find_buffers_to_auto_procure()
+                for in_buffer in in_buffers.with_context(no_ddmrp_history=True):
+                    in_buffer.do_auto_procure()
         return res
 
     @api.model_create_multi
@@ -73,6 +78,24 @@ class StockMove(models.Model):
                 )
             )
         return out_buffers, in_buffers
+
+    def _find_buffers_to_auto_procure(self):
+        # If a quantity is increased at a buffer replenishment location, this
+        # could release a new auto procure
+        in_buffers = self.env["stock.buffer"]
+        for move in self:
+            in_buffers |= move.mapped("product_id.buffer_ids").filtered(
+                lambda buffer: (
+                    buffer.distributed_source_location_id
+                    and not move.location_id.is_sublocation_of(
+                        buffer.distributed_source_location_id
+                    )
+                    and move.location_dest_id.is_sublocation_of(
+                        buffer.distributed_source_location_id
+                    )
+                )
+            )
+        return in_buffers
 
     def _update_ddmrp_nfp(self):
         if self.env.context.get("no_ddmrp_auto_update_nfp"):

--- a/ddmrp/readme/CONTRIBUTORS.rst
+++ b/ddmrp/readme/CONTRIBUTORS.rst
@@ -2,3 +2,4 @@
 * Lois Rilo Antelo <lois.rilo@forgeflow.com>
 * Guewen Baconnier <guewen.baconnier@camptocamp.com>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
+* Jacques-Etienne Baudoux (BCIM) <je@bcim.be>

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -464,6 +464,6 @@ class TestDdmrpCommon(common.SavepointCase):
 
     def _do_move(self, move, date):
         move._action_confirm()
-        move.move_line_ids.qty_done = move.move_line_ids.product_uom_qty
+        move.quantity_done = move.product_uom_qty
         move._action_done()
         move.date = date


### PR DESCRIPTION
Port of #197

In auto procure, if the profile is configured in distributed with a
limit to free qty, it is possible that not all the required quantity is
replenished. When the quantity increases at the replenishment location,
a new auto procurement should be triggered.