### PR TITLE
[14.0][FIX] ddmrp: method moved to purchase.order.line model

### DIFF
--- a/ddmrp/models/purchase_order.py
+++ b/ddmrp/models/purchase_order.py
@@ -91,3 +91,17 @@ class PurchaseOrderLine(models.Model):
             if buffer:
                 rec.buffer_ids = buffer
                 rec._calc_execution_priority()
+
+    def _prepare_purchase_order_line_from_procurement(
+        self, product_id, product_qty, product_uom, company_id, values, po
+    ):
+        vals = super()._prepare_purchase_order_line_from_procurement(
+            product_id, product_qty, product_uom, company_id, values, po
+        )
+        # If the procurement was run directly by a reordering rule.
+        if "buffer_id" in values:
+            vals["buffer_ids"] = [(4, values["buffer_id"].id)]
+        # If the procurement was run by a stock move.
+        elif "buffer_ids" in values:
+            vals["buffer_ids"] = [(4, o.id) for o in values["buffer_ids"]]
+        return vals

--- a/ddmrp/models/stock_rule.py
+++ b/ddmrp/models/stock_rule.py
@@ -78,20 +78,6 @@ class StockRule(models.Model):
             vals["buffer_ids"] = [(4, o.id) for o in values["buffer_ids"]]
         return vals
 
-    def _prepare_purchase_order_line(
-        self, product_id, product_qty, product_uom, company_id, values, po
-    ):
-        vals = super()._prepare_purchase_order_line(
-            product_id, product_qty, product_uom, company_id, values, po
-        )
-        # If the procurement was run directly by a reordering rule.
-        if "buffer_id" in values:
-            vals["buffer_ids"] = [(4, values["buffer_id"].id)]
-        # If the procurement was run by a stock move.
-        elif "buffer_ids" in values:
-            vals["buffer_ids"] = [(4, o.id) for o in values["buffer_ids"]]
-        return vals
-
     def _update_purchase_order_line(
         self, product_id, product_qty, product_uom, company_id, values, line
     ):


### PR DESCRIPTION
method moved to purchase.order.line model
v13
https://github.com/odoo/odoo/blob/1d8424434b2caee89dc6daa4a43f25c5728f481f/addons/purchase_stock/models/stock_rule.py#L122
v14
https://github.com/odoo/odoo/blob/cd38b56b2df13dc8e7890c7fdaea39b1b60fa3c1/addons/purchase_stock/models/stock_rule.py#L138

I would expect this place should fail 
https://github.com/OCA/ddmrp/blob/ad43447eb24f5488e4511c2ce6e27f8f79d00e8f/ddmrp/tests/test_ddmrp.py#L748
but it passes suppose because of the buffer is set in the context of the wizard and question than do we need this method in this case

to be checked 