### PR TITLE
[14.0][IMP] ddmrp: add an index on 'stock_move_line.state'

### DIFF
--- a/ddmrp/models/__init__.py
+++ b/ddmrp/models/__init__.py
@@ -12,6 +12,7 @@ from . import stock_warehouse
 from . import stock_buffer
 from . import product_template
 from . import stock_move
+from . import stock_move_line
 from . import stock_picking
 from . import res_company
 from . import product_product

--- a/ddmrp/models/stock_move_line.py
+++ b/ddmrp/models/stock_move_line.py
@@ -1,0 +1,12 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from odoo import fields, models
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    # Override to make '_compute_product_available_qty' method of
+    # 'stock.buffer' more efficient.
+    state = fields.Selection(index=True)


### PR DESCRIPTION
This allows to improve the performance when accessing the list of DDMRP
buffers.
The field `_compute_product_available_qty` method of `stock.buffer` is
searching for `stock.move.line` records based on their status.

Forward port of https://github.com/OCA/ddmrp/pull/161.