### PR TITLE
[15.0] ddmrp: add index on 'distributed_source_location_id'

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1103,6 +1103,7 @@ class StockBuffer(models.Model):
         string="Replenishment Location",
         comodel_name="stock.location",
         readonly=True,
+        index=True,
         help="Source location from where goods will be replenished. "
         "Computed when buffer is refreshed from following the Stock Rules.",
     )


### PR DESCRIPTION
The filter on 'distributed_source_location_qty' is using a
search method querying the 'distributed_source_location_id' field having
no index.

Forward port #191 