### PR TITLE
[15.0][FIX] ddmrp: adu field needs to be explicity written when adu_fixed is set

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1147,10 +1147,6 @@ class StockBuffer(models.Model):
         )
         return [("id", "in", buffers.ids)]
 
-    @api.onchange("adu_fixed", "adu_calculation_method")
-    def onchange_adu(self):
-        self._calc_adu()
-
     def _search_open_stock_moves_domain(self):
         self.ensure_one()
         return [
@@ -1533,6 +1529,8 @@ class StockBuffer(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         records = super().create(vals_list)
+        if not self.env.context.get("skip_adu_calculation", False):
+            records._calc_adu()
         records._calc_distributed_source_location()
         return records
 


### PR DESCRIPTION
The onchange only has a visual effect. Actual changes to adu must be made in
the create and write methods.

@LoisRForgeFlow @BernatPForgeFlow 