### PR TITLE
[14.0][FIX] planning chart display in ddmrp_history

### DIFF
--- a/ddmrp_history/models/stock_buffer.py
+++ b/ddmrp_history/models/stock_buffer.py
@@ -113,6 +113,8 @@ class StockBuffer(models.Model):
             min_y = min(
                 [0, min(data["on_hand_position"]), min(data["net_flow_position"])]
             )
+            if top_y <= min_y:
+                top_y = min_y + 100
             p = figure(
                 x_range=(dates[0], dates[-1]),
                 y_range=(min_y, top_y),


### PR DESCRIPTION
When displaying some buffers there is an error coming up from the bokeh library:

    Error: invalid bbox {left: NaN, top: NaN, right: NaN, bottom: NaN}

And the planning chart is not displayed.

The error happens because max and min top are zeros.