### PR TITLE
[13.0][IMP] ddmrp: Add hook to get produce delay

### DIFF
--- a/ddmrp/models/mrp_bom.py
+++ b/ddmrp/models/mrp_bom.py
@@ -47,6 +47,10 @@ class MrpBom(models.Model):
         for bom in self:
             bom.is_buffered = True if bom.buffer_id else False
 
+    def _get_produce_delay(self):
+        self.ensure_one()
+        return self.product_id.produce_delay or self.product_tmpl_id.produce_delay
+
     def _get_longest_path(self):
         if not self.bom_line_ids:
             return 0.0
@@ -63,11 +67,7 @@ class MrpBom(models.Model):
                     lambda bom: bom.location_id == location
                 ) or line_boms.filtered(lambda bom: not bom.location_id)
                 if bom:
-                    produce_delay = (
-                        bom[0].product_id.produce_delay
-                        or bom[0].product_tmpl_id.produce_delay
-                    )
-                    paths[i] += produce_delay
+                    paths[i] += bom[0]._get_produce_delay()
                     paths[i] += bom[0]._get_longest_path()
                 else:
                     _logger.info(
@@ -91,7 +91,7 @@ class MrpBom(models.Model):
         """Computes the Decoupled Lead Time exploding all the branches of the
         BOM until a buffered position and then selecting the greatest."""
         self.ensure_one()
-        dlt = self.product_id.produce_delay or self.product_tmpl_id.produce_delay
+        dlt = self._get_produce_delay()
         dlt += self._get_longest_path()
         return dlt
 


### PR DESCRIPTION
A hook is added to get production delay because subcontracting BoMs calculate production time differently, from the time of the first vendor with subcontracted type.

Backport of #243 