### PR TITLE
[14.0][FIX] ddmrp: use archived locations in the ADU computation

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -188,8 +188,10 @@ class StockBuffer(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id(
             "ddmrp.stock_move_year_consumption_action"
         )
-        locations = self.env["stock.location"].search(
-            [("id", "child_of", [self.location_id.id])]
+        locations = (
+            self.env["stock.location"]
+            .with_context(active_test=False)
+            .search([("id", "child_of", self.location_id.ids)])
         )
         date_to = fields.Date.today()
         # We take last five years, even though they will be initially
@@ -1420,8 +1422,10 @@ class StockBuffer(models.Model):
         # today is excluded to be sure that is a past day and all moves
         # for that day are done (or at least the expected date is in the past).
         date_from, date_to = self._get_dates_adu_past_demand(horizon)
-        locations = self.env["stock.location"].search(
-            [("id", "child_of", [self.location_id.id])]
+        locations = (
+            self.env["stock.location"]
+            .with_context(active_test=False)
+            .search([("id", "child_of", self.location_id.ids)])
         )
         if self.adu_calculation_method.source_past == "estimates":
             qty = 0.0


### PR DESCRIPTION
When computing the ADU from X past days, archived locations are not taken into account, resulting in a wrong qty.
Same issue for the consumption view.

Ref. 4064