### PR TITLE
[15.0][FIX] ddmrp: remove unneded inheritance

### DIFF
--- a/ddmrp/models/mrp_production.py
+++ b/ddmrp/models/mrp_production.py
@@ -24,17 +24,6 @@ class MrpProduction(models.Model):
         string="On Hand/TOR (%)",
     )
 
-    # TODO: remove after PR https://github.com/odoo/odoo/pull/25424 has
-    # been merged
-    def _generate_finished_moves(self):
-        move = super(MrpProduction, self)._generate_finished_moves()
-        move.write(
-            {
-                "date": self.date_planned_finished,
-            }
-        )
-        return move
-
     @api.model
     def create(self, vals):
         record = super(MrpProduction, self).create(vals)


### PR DESCRIPTION
upstream _generate_finished_moves does not exist since v14, the equivalent extesion for should be done in
_get_move_finished_values, however is not needed as Odoo has already corrected the issue.

Forward port of #272 and #277