### PR TITLE
[15.0][FIX] ddmrp: incorrect handling of reservation UoM computing demand.

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1602,7 +1602,11 @@ class StockBuffer(models.Model):
             demand_by_days[move_date] = 0.0
         for move in moves:
             date = move.date.date()
-            demand_by_days[date] += move.product_qty - move.reserved_availability
+            demand_by_days[
+                date
+            ] += move.product_qty - move.product_uom._compute_quantity(
+                move.reserved_availability, move.product_id.uom_id
+            )
         return demand_by_days
 
     def _search_mrp_moves_qualified_demand_domain(self):

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -74,6 +74,7 @@ class TestDdmrpCommon(common.TransactionCase):
             }
         )
         cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.dozen_unit = cls.env.ref("uom.product_uom_dozen")
         cls.buffer_profile_pur = cls.env.ref(
             "ddmrp.stock_buffer_profile_replenish_purchased_medium_medium"
         )
@@ -318,7 +319,9 @@ class TestDdmrpCommon(common.TransactionCase):
         )
         return user
 
-    def create_pickingoutA(self, date_move, qty):
+    def create_pickingoutA(self, date_move, qty, uom=False):
+        if not uom:
+            uom = self.productA.uom_id
         picking = self.pickingModel.with_user(self.user).create(
             {
                 "picking_type_id": self.picking_type_out.id,
@@ -333,7 +336,7 @@ class TestDdmrpCommon(common.TransactionCase):
                             "name": "Test move",
                             "product_id": self.productA.id,
                             "date": date_move,
-                            "product_uom": self.productA.uom_id.id,
+                            "product_uom": uom.id,
                             "product_uom_qty": qty,
                             "location_id": self.binA.id,
                             "location_dest_id": self.customer_location.id,

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -414,6 +414,23 @@ class TestDdmrp(TestDdmrpCommon):
             self.buffer_a.product_location_qty_available_not_res, expected_on_hand
         )
 
+    def test_19_qualified_demand_6_uom(self):
+        """Delivery spike in a secondary UoM and partially reserved, only
+        unreserved part should be considered."""
+        date_move = datetime.today() + timedelta(days=10)
+        picking = self.create_pickingoutA(date_move, 20, uom=self.dozen_unit)
+        available_qty = self.buffer_a.product_location_qty_available_not_res
+        picking.action_assign()
+        self.assertEqual(picking.move_lines.state, "partially_available")
+        self.bufferModel.cron_ddmrp()
+        # 20 dozens minus de available qty that has been reserved in this
+        # picking.
+        expected_result = (20 * 12) - available_qty
+        self.assertTrue(expected_result > self.buffer_a.order_spike_threshold)
+        self.assertAlmostEqual(
+            self.buffer_a.qualified_demand, expected_result, places=0
+        )
+
     # TEST GROUP 2: Buffer zones and procurement
 
     def _check_red_zone(


### PR DESCRIPTION
A new test case is added to highlight the problem.

Forward port of #302 