### PR TITLE
[14.0][FIX] ddmrp: consider multicompany when finding BoMs

### DIFF
--- a/ddmrp/models/mrp_bom.py
+++ b/ddmrp/models/mrp_bom.py
@@ -34,6 +34,8 @@ class MrpBom(models.Model):
         domain = [("product_id", "=", product.id)]
         if self.location_id:
             domain.append(("location_id", "=", self.location_id.id))
+        if self.company_id:
+            domain.append(("company_id", "=", self.company_id.id))
         return domain
 
     @api.depends("product_id", "product_tmpl_id", "location_id")
@@ -128,6 +130,8 @@ class MrpBomLine(models.Model):
         domain = [("product_id", "=", product.id)]
         if self.location_id:
             domain.append(("location_id", "=", self.location_id.id))
+        if self.company_id:
+            domain.append(("company_id", "=", self.company_id.id))
         return domain
 
     def _compute_is_buffered(self):

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -218,14 +218,8 @@ class StockBuffer(models.Model):
 
     def action_view_bom(self):
         action = self.product_id.action_view_bom()
-        locations = self.env["stock.location"].search(
-            [("id", "child_of", [self.location_id.id])]
-        )
-        action["domain"] += [
-            "|",
-            ("location_id", "in", locations.ids),
-            ("location_id", "=", False),
-        ]
+        boms = self._get_manufactured_bom(limit=100)
+        action["domain"] = [("id", "in", boms.ids)]
         return action
 
     @api.constrains("product_id")
@@ -930,7 +924,7 @@ class StockBuffer(models.Model):
         for rec in self:
             rec.order_spike_threshold = 0.5 * rec.red_zone_qty
 
-    def _get_manufactured_bom(self):
+    def _get_manufactured_bom(self, limit=1):
         locations = self.env["stock.location"].search(
             [("id", "child_of", [self.location_id.id])]
         )
@@ -942,8 +936,11 @@ class StockBuffer(models.Model):
                 "|",
                 ("location_id", "in", locations.ids),
                 ("location_id", "=", False),
+                "|",
+                ("company_id", "=", self.company_id.id),
+                ("company_id", "=", False),
             ],
-            limit=1,
+            limit=limit,
         )
 
     @api.depends("lead_days", "product_id.seller_ids.delay")

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -43,6 +43,7 @@ class TestDdmrpCommon(common.SavepointCase):
 
         # Refs
         cls.main_company = cls.env.ref("base.main_company")
+        cls.second_company = cls.env.ref("stock.res_company_1")
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.warehouse2 = cls.wh_model.create(
             {
@@ -51,7 +52,9 @@ class TestDdmrpCommon(common.SavepointCase):
                 "code": "WH2",
             }
         )
+        cls.warehouse_sc = cls.env.ref("stock.stock_warehouse_shop0")
         cls.stock_location = cls.env.ref("stock.stock_location_stock")
+        cls.stock_location_sc = cls.warehouse_sc.lot_stock_id
         cls.location_shelf1 = cls.env.ref("stock.stock_location_components")
         cls.supplier_location = cls.env.ref("stock.stock_location_suppliers")
         cls.customer_location = cls.env.ref("stock.stock_location_customers")

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -951,6 +951,41 @@ class TestDdmrp(TestDdmrpCommon):
         new_green = (dlt + extra) * adu * 0.5
         self.assertEqual(self.buffer_c_blue.green_zone_qty, new_green)
 
+    def test_37_bom_buffer_fields_multi_company(self):
+        self.assertEqual(self.bom_a.company_id, self.main_company)
+        self.assertTrue(self.bom_a.is_buffered)
+        self.assertEqual(self.bom_a.buffer_id, self.buffer_a)
+        bom_buffer_a = self.buffer_a._get_manufactured_bom()
+        self.assertEqual(bom_buffer_a, self.bom_a)
+        bom_line = self.bom_a.bom_line_ids.filtered(
+            lambda l: l.product_id == self.component_a1
+        )
+        self.assertTrue(bom_line)
+        self.assertFalse(bom_line.is_buffered)
+        # Add a buffer for a component but in a different company
+        component_buffer = self.bufferModel.create(
+            {
+                "buffer_profile_id": self.buffer_profile_pur.id,
+                "product_id": self.component_a1.id,
+                "company_id": self.second_company.id,
+                "warehouse_id": self.warehouse_sc.id,
+                "location_id": self.stock_location_sc.id,
+                "adu_calculation_method": self.adu_fixed.id,
+            }
+        )
+        bom_line.invalidate_cache()
+        self.assertFalse(bom_line.is_buffered)
+        # Change company of the BoM
+        self.bom_a.company_id = self.second_company
+        self.bom_a.invalidate_cache()
+        self.assertFalse(self.bom_a.is_buffered)
+        self.assertFalse(self.bom_a.buffer_id)
+        bom_buffer_a = self.buffer_a._get_manufactured_bom()
+        self.assertFalse(bom_buffer_a)
+        bom_line.invalidate_cache()
+        self.assertTrue(bom_line.is_buffered)
+        self.assertEqual(bom_line.buffer_id, component_buffer)
+
     def test_40_bokeh_charts(self):
         """Check bokeh chart computation."""
         date_move = datetime.today()


### PR DESCRIPTION
A test case is added to avoid regressions.

Forward port of #305 