### PR TITLE
[16.0][FIX] ddmrp: do not open twice buffer popover from list view.

### DIFF
--- a/ddmrp/static/src/widgets/stock_buffer_info.esm.js
+++ b/ddmrp/static/src/widgets/stock_buffer_info.esm.js
@@ -126,21 +126,23 @@ export class StockBufferInfoWidget extends FloatField {
         ev.stopPropagation();
         ev.preventDefault();
         this.updateCalcData();
-        this.closePopover = this.popover.add(
-            ev.currentTarget,
-            this.constructor.components.Popover,
-            {
-                bus: this.bus,
-                record: this.props.record,
-                calcData: this.calcData,
-                field: this.props.field,
-                color_from: this.props.color_from,
-            },
-            {
-                position: "right",
-            }
-        );
-        this.bus.addEventListener("close-popover", this.closePopover);
+        if (!this.closePopover) {
+            this.closePopover = this.popover.add(
+                ev.currentTarget,
+                this.constructor.components.Popover,
+                {
+                    bus: this.bus,
+                    record: this.props.record,
+                    calcData: this.calcData,
+                    field: this.props.field,
+                    color_from: this.props.color_from,
+                },
+                {
+                    position: "right",
+                }
+            );
+            this.bus.addEventListener("close-popover", this.closePopover);
+        }
     }
 }
 


### PR DESCRIPTION
Before this commit, clicking twice in the status bubble will open two popups:

![2023-10-13_09-07](https://github.com/OCA/ddmrp/assets/23449160/acf98346-7a1b-40cf-91aa-fc3d595f4dcf)

