### PR TITLE
[16.0][FIX] ddmrp, bom structure report variable lead time should be a boolean in case of empty

### DIFF
--- a/ddmrp/report/mrp_report_bom_structure.py
+++ b/ddmrp/report/mrp_report_bom_structure.py
@@ -75,7 +75,7 @@ class BomStructureReport(models.AbstractModel):
                 or 0.0
             )
         res["is_buffered"] = bom_line.is_buffered
-        res["lead_time"] = lead_time or ""
+        res["lead_time"] = lead_time or False
         res["dlt"] = bom_line.dlt
         return res
 


### PR DESCRIPTION
Version 16 raise error bom structure report when lead time is zero, variable should be a boolean not empty string