### PR TITLE
[14.0][FIX]ddmrp: initialize defaultdict with actual model

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -376,7 +376,7 @@ class StockBuffer(models.Model):
         return sum(lines.mapped("product_qty"))
 
     def _compute_product_available_qty(self):
-        operation_by_location = defaultdict(lambda: self.env["stock.buffer"])
+        operation_by_location = defaultdict(lambda: self.browse())
         for rec in self:
             operation_by_location[rec.location_id] |= rec
         for location_id, buffer_in_location in operation_by_location.items():


### PR DESCRIPTION
If there is a new model inheriting the actual `stock.buffer` model, such as the `stock.simulation.buffer`, then the method will fail as the values from `self` will be from a different model. This is fixed by changing the initialization to an empty record of self.

Fwport of #330 