### PR TITLE
[16.0][FIX] ddmrp_history: remove blank space after charts

### DIFF
--- a/ddmrp_history/models/stock_buffer.py
+++ b/ddmrp_history/models/stock_buffer.py
@@ -115,7 +115,7 @@ class StockBuffer(models.Model):
                 y_range=(min_y, top_y),
                 x_axis_type="datetime",
             )
-            p.sizing_mode = "scale_width"
+            p.sizing_mode = "stretch_width"
             p.toolbar.logo = None
 
             p.grid.minor_grid_line_color = "#eeeeee"
@@ -265,7 +265,7 @@ class StockBuffer(models.Model):
                 y_range=(start_stack, top_y or 100),
                 x_axis_type="datetime",
             )
-            p.sizing_mode = "scale_width"
+            p.sizing_mode = "stretch_width"
             p.toolbar.logo = None
 
             p.grid.minor_grid_line_color = "#eeeeee"

--- a/ddmrp_history/views/stock_buffer_view.xml
+++ b/ddmrp_history/views/stock_buffer_view.xml
@@ -12,21 +12,21 @@
                     <div style="margin-top: 1em;">
                         <field
                             name="planning_history_chart"
-                            style="height:400px;width:100%"
+                            style="width:100%"
                             widget="bokeh_chart"
                             nolabel="1"
                         />
                     </div>
                 </page>
                 <page name="execution_history" string="Execution Chart">
-                        <div style="margin-top: 1em;">
-                            <field
+                    <div style="margin-top: 1em;">
+                        <field
                             name="execution_history_chart"
-                            style="height:400px;width:100%"
+                            style="width:100%"
                             widget="bokeh_chart"
                             nolabel="1"
                         />
-                        </div>
+                    </div>
                 </page>
             </notebook>
         </field>


### PR DESCRIPTION
Before:
![image](https://github.com/OCA/ddmrp/assets/23449160/c64144c4-5458-4eba-8173-fe71bfef5811)

After:
![image](https://github.com/OCA/ddmrp/assets/23449160/37dbd6c4-a18c-47f4-b698-d595f9530a96)
