### PR TITLE
[13.0][IMP] ddmrp*: Add stored fields and remove non used

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -327,21 +327,8 @@ class StockBuffer(models.Model):
 
     # STOCK INFORMATION:
 
-    product_location_qty = fields.Float(
-        string="Quantity On Location", compute="_compute_product_available_qty"
-    )
-    incoming_location_qty = fields.Float(
-        string="Incoming On Location", compute="_compute_product_available_qty"
-    )
-    outgoing_location_qty = fields.Float(
-        string="Outgoing On Location", compute="_compute_product_available_qty"
-    )
-    virtual_location_qty = fields.Float(
-        string="Forecast On Location", compute="_compute_product_available_qty"
-    )
     product_location_qty_available_not_res = fields.Float(
         string="Quantity On Hand (Unreserved)",
-        compute="_compute_product_available_qty",
         help="Quantity available in this stock buffer, this is the total "
         "quantity on hand minus the outgoing reservations.",
     )
@@ -360,7 +347,17 @@ class StockBuffer(models.Model):
         )
         return sum(lines.mapped("product_qty"))
 
-    def _compute_product_available_qty(self):
+    def _update_quantities_dict(self, product):
+        self.ensure_one()
+        reserved_qty = self._get_outgoing_reservation_qty()
+        self.update(
+            {
+                "product_location_qty_available_not_res": product["qty_available"]
+                - reserved_qty,
+            }
+        )
+
+    def _calc_product_available_qty(self):
         operation_by_location = defaultdict(lambda: self.browse())
         for rec in self:
             operation_by_location[rec.location_id] |= rec
@@ -376,19 +373,7 @@ class StockBuffer(models.Model):
             )
             for buffer in buffer_in_location:
                 product = products[buffer.product_id.id]
-                reserved_qty = buffer._get_outgoing_reservation_qty()
-                buffer.update(
-                    {
-                        "product_location_qty": product["qty_available"],
-                        "incoming_location_qty": product["incoming_qty"],
-                        "outgoing_location_qty": product["outgoing_qty"],
-                        "virtual_location_qty": product["virtual_available"],
-                        "product_location_qty_available_not_res": product[
-                            "qty_available"
-                        ]
-                        - reserved_qty,
-                    }
-                )
+                buffer._update_quantities_dict(product)
 
     # PURCHASES LINK:
 
@@ -1126,6 +1111,7 @@ class StockBuffer(models.Model):
     )
     qualified_demand_stock_move_ids = fields.Many2many(comodel_name="stock.move",)
     qualified_demand_mrp_move_ids = fields.Many2many(comodel_name="mrp.move",)
+    incoming_total_qty = fields.Float(string="Total Incoming", readonly=True,)
     incoming_dlt_qty = fields.Float(string="Incoming (Within DLT)", readonly=True)
     incoming_outside_dlt_qty = fields.Float(
         string="Incoming (Outside DLT)", readonly=True,
@@ -1622,6 +1608,7 @@ class StockBuffer(models.Model):
                 rec.rfq_outside_dlt_qty = sum(pols.mapped("product_qty"))
             else:
                 rec.rfq_outside_dlt_qty = 0.0
+            rec.incoming_total_qty = rec.incoming_dlt_qty + rec.incoming_outside_dlt_qty
         return True
 
     def _calc_net_flow_position(self):
@@ -1686,6 +1673,9 @@ class StockBuffer(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         records = super().create(vals_list)
+        if not self.env.context.get("skip_adu_calculation", False):
+            records._calc_adu()
+        records._calc_product_available_qty()
         records._calc_distributed_source_location()
         return records
 
@@ -1893,16 +1883,13 @@ class StockBuffer(models.Model):
         self.ensure_one()
         self.invalidate_cache(
             fnames=[
-                "product_location_qty",
-                "incoming_location_qty",
-                "outgoing_location_qty",
-                "virtual_location_qty",
                 "product_location_qty_available_not_res",
                 "dlt",
                 "distributed_source_location_qty",
             ],
             ids=self.ids,
         )
+        self._calc_product_available_qty()
         if not only_nfp or only_nfp == "out":
             self._calc_qualified_demand()
         if not only_nfp or only_nfp == "in":

--- a/ddmrp/models/stock_move_line.py
+++ b/ddmrp/models/stock_move_line.py
@@ -7,6 +7,6 @@ from odoo import fields, models
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    # Override to make '_compute_product_available_qty' method of
+    # Override to make '_calc_product_available_qty' method of
     # 'stock.buffer' more efficient.
     state = fields.Selection(index=True)

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -39,7 +39,7 @@
                 />
                 <field name="incoming_dlt_qty" string="Incoming Within DLT" />
                 <field
-                    name="incoming_location_qty"
+                    name="incoming_total_qty"
                     string="Total Incoming"
                     optional="show"
                 />

--- a/ddmrp_product_replace/models/stock_buffer.py
+++ b/ddmrp_product_replace/models/stock_buffer.py
@@ -124,17 +124,17 @@ class StockBuffer(models.Model):
             res += rec
         return res
 
-    def _compute_product_available_qty(self):
-        res = super()._compute_product_available_qty()
+    def _calc_product_available_qty(self):
+        res = super()._calc_product_available_qty()
         for rec in self:
             if not (rec.use_replacement_for_buffer_status and rec.replacement_for_ids):
                 continue
             for buffer in rec.replacement_for_ids:
-                # Update 'incoming_location_qty'
+                # Update 'incoming_total_qty'
                 replacements_incoming_qty = buffer.product_uom._compute_quantity(
-                    buffer.incoming_location_qty, rec.product_uom, round=False,
+                    buffer.incoming_total_qty, rec.product_uom, round=False,
                 )
-                rec.incoming_location_qty += replacements_incoming_qty
+                rec.incoming_total_qty += replacements_incoming_qty
                 # Update 'product_location_qty_available_not_res'
                 replacements_qty_not_res = buffer.product_uom._compute_quantity(
                     buffer.product_location_qty_available_not_res,

--- a/ddmrp_product_replace/tests/test_product_replace.py
+++ b/ddmrp_product_replace/tests/test_product_replace.py
@@ -91,7 +91,7 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
         self.assertEqual(old_onhand, -60.0)
         old_incoming_dlt_qty = self.buffer.incoming_dlt_qty
         self.assertEqual(old_incoming_dlt_qty, 30.0)
-        old_incoming_qty = self.buffer.incoming_location_qty
+        old_incoming_qty = self.buffer.incoming_total_qty
         self.assertEqual(old_incoming_qty, 30.0)
         wiz = self.env["ddmrp.product.replace"].create(
             {
@@ -127,7 +127,7 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
         self.buffer.cron_actions()
         self.assertEqual(old_onhand, new_buffer.product_location_qty_available_not_res)
         self.assertEqual(old_incoming_dlt_qty, new_buffer.incoming_dlt_qty)
-        self.assertEqual(old_incoming_qty, new_buffer.incoming_location_qty)
+        self.assertEqual(old_incoming_qty, new_buffer.incoming_total_qty)
         new_buffer.invalidate_cache()
         new_buffer.use_replacement_for_buffer_status = False
         new_buffer.cron_actions()
@@ -135,7 +135,7 @@ class TestDDMRPProductReplace(TestDdmrpCommon):
             old_onhand, new_buffer.product_location_qty_available_not_res
         )
         self.assertNotEqual(old_incoming_dlt_qty, new_buffer.incoming_dlt_qty)
-        self.assertNotEqual(old_incoming_qty, new_buffer.incoming_location_qty)
+        self.assertNotEqual(old_incoming_qty, new_buffer.incoming_total_qty)
         # Demand:
         self.assertIn(self.old_product, new_buffer.demand_product_ids)
         self.assertEqual(new_buffer.qualified_demand, 0)

--- a/stock_buffer_capacity_limit/models/stock_buffer.py
+++ b/stock_buffer_capacity_limit/models/stock_buffer.py
@@ -8,6 +8,7 @@ from odoo.tools import float_compare
 class StockBuffer(models.Model):
     _inherit = "stock.buffer"
 
+    product_location_qty = fields.Float(string="Quantity On Location",)
     storage_capacity_limit = fields.Float(
         digits="Product Unit of Measure",
         help="The system will never propose a procurement that would move "
@@ -15,6 +16,15 @@ class StockBuffer(models.Model):
         "this limit, even if this means that you have planning or "
         "execution alerts.",
     )
+
+    def _update_quantities_dict(self, product):
+        res = super()._update_quantities_dict(product)
+        self.update({"product_location_qty": product["qty_available"]})
+        return res
+
+    def cron_actions(self, only_nfp=False):
+        self.invalidate_cache(fnames=["product_location_qty"], ids=self.ids)
+        return super().cron_actions(only_nfp)
 
     @api.depends("storage_capacity_limit")
     def _compute_procure_recommended_qty(self):


### PR DESCRIPTION
All fields will be stored since Stock Buffer is a static entity that refreshes its information via a daily cron or a refresh button.
If we keep compute fields, we can face inconsistencies between the stored data and the computed one.

Backport of #341 