### PR TITLE
[16.0][FIX] ddmrp: minor leftovers from migration

### DIFF
--- a/ddmrp/static/src/widgets/stock_buffer_info.esm.js
+++ b/ddmrp/static/src/widgets/stock_buffer_info.esm.js
@@ -23,9 +23,31 @@ export class StockBufferPopover extends Component {
                     "/web_widget_bokeh_chart/static/src/lib/bokeh/bokeh-gl-3.1.1.min.js",
                 ],
             });
+            var bufferId = this.props.record.resId;
+            var bufferField = this.props.buffer_id;
+            if (bufferField && this.props.record.data[bufferField]) {
+                if (
+                    "field" in this.props.record.data[bufferField] &&
+                    this.props.record.data[bufferField].field.type == "many2many"
+                ) {
+                    if (this.props.record.data[bufferField].records.length > 0) {
+                        bufferId = this.props.record.data[bufferField].records[0].resId;
+                    } else {
+                        bufferId = 0; // Relation is blank, no buffer.
+                    }
+                } else {
+                    // Assume m2o
+                    bufferId = this.props.record.data[bufferField][0];
+                }
+            } else if (bufferField) {
+                bufferId = 0; // Relation is blank, no buffer.
+            }
+            if (bufferId == 0) {
+                return;
+            }
             this.bokeh_chart = await this.orm.read(
-                this.props.record.resModel,
-                [this.props.record.resId],
+                "stock.buffer",
+                [bufferId],
                 [this.props.field]
             );
         });
@@ -68,6 +90,7 @@ export class StockBufferInfoWidget extends FloatField {
                 record: this.props.record,
                 field: this.props.field,
                 color_from: this.props.color_from,
+                buffer_id: this.props.buffer_id,
             },
             {
                 position: "right",
@@ -86,6 +109,7 @@ StockBufferInfoWidget.props = {
     ...StockBufferInfoWidget.props,
     color_from: {type: String, optional: true},
     field: {type: String, optional: true},
+    buffer_id: {type: String, optional: true},
 };
 
 const StockBufferInfoWidgetExtractProps = StockBufferInfoWidget.extractProps;
@@ -93,6 +117,7 @@ StockBufferInfoWidget.extractProps = ({attrs, field}) => {
     return Object.assign(StockBufferInfoWidgetExtractProps({attrs, field}), {
         color_from: attrs.options.color_from,
         field: attrs.options.field,
+        buffer_id: attrs.options.buffer_id,
     });
 };
 

--- a/ddmrp/views/mrp_production_view.xml
+++ b/ddmrp/views/mrp_production_view.xml
@@ -10,7 +10,8 @@
                 <field name="execution_priority_level" invisible="1" />
                 <field
                     name="on_hand_percent"
-                    options='{"buffer_id": "buffer_id", "color_from": "execution_priority_level"}'
+                    options='{"buffer_id": "buffer_id", "color_from": "execution_priority_level", "field": "ddmrp_chart_execution"}'
+                    widget="stock_buffer_info"
                 />
             </field>
         </field>

--- a/ddmrp/views/purchase_order_line_view.xml
+++ b/ddmrp/views/purchase_order_line_view.xml
@@ -18,7 +18,8 @@
                 <field name="execution_priority_level" invisible="1" />
                 <field
                     name="on_hand_percent"
-                    options='{"buffer_ids": "buffer_ids", "color_from": "execution_priority_level"}'
+                    options='{"buffer_id": "buffer_ids", "color_from": "execution_priority_level", "field": "ddmrp_chart_execution"}'
+                    widget="stock_buffer_info"
                 />
                 <field name="product_qty" readonly="True" />
                 <field name="product_id" readonly="True" />

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -497,33 +497,30 @@
                         <page name="zones_info" string="Zones Information">
                             <group col="3">
                                 <group name="green_zone" string="Green zone">
-                                    <div class="no_print">
+                                    <div class="no_print" colspan="2">
                                         <p
                                             class="oe_grey"
                                         >The green zone determines the average order frequency and the order size. It is determined as the maximum of the following three factors: Minimum Order Cycle, Lead Time Factor and Minimum Order Quantity.</p>
                                     </div>
-                                    <div />
                                     <field name="green_zone_oc" />
                                     <field name="green_zone_moq" />
                                     <field name="green_zone_lt_factor" />
                                     <field name="green_zone_qty" />
                                 </group>
                                 <group name="yellow_zone" string="Yellow zone">
-                                    <div class="no_print">
+                                    <div class="no_print" colspan="2">
                                         <p
                                             class="oe_grey"
                                         >The yellow zone represents the stock required to cover a full lead time.</p>
                                     </div>
-                                    <div />
                                     <field name="yellow_zone_qty" />
                                 </group>
                                 <group name="red_zone" string="Red zone">
-                                    <div class="no_print">
+                                    <div class="no_print" colspan="2">
                                         <p
                                             class="oe_grey"
                                         >The red zone is the embedded safety in the buffer. The larger the variability associated with the product, the larger the red zone will be. It is composed of two sub-zones: Red base and red safety.</p>
                                     </div>
-                                    <div />
                                     <field name="red_base_qty" />
                                     <field name="red_safety_qty" />
                                     <field name="red_zone_qty" />

--- a/ddmrp/wizards/res_config_settings_views.xml
+++ b/ddmrp/wizards/res_config_settings_views.xml
@@ -13,6 +13,7 @@
                 <div
                     class="app_settings_block"
                     data-string="DDMRP"
+                    string="DDMRP"
                     data-key="ddmrp"
                     groups="ddmrp.group_ddmrp_manager"
                 >


### PR DESCRIPTION
- stock_buffer_info widget should support relation to buffers in other models.
- Show string in settings block.
- fix zones information tab in stock buffer form view.