### PR TITLE
[16.0][FIX] ddmrp: rename filter planning_priority_level

### DIFF
--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -554,7 +554,7 @@
                 <field name="execution_priority_level" />
                 <group name="planning_priority" string="Planning Priority Zones">
                     <filter
-                        name="planning_priority_level"
+                        name="planning_priority_level_red"
                         string="Red"
                         domain="[('planning_priority_level', '=', '1_red')]"
                     />


### PR DESCRIPTION
Otherwise it throws an error when calling it programatically, as it is confused with the field with the same name