### PR TITLE
[16.0][FIX] ddmrp: Boolean toggle should not autosave

### DIFF
--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -326,6 +326,7 @@
                                     name="show_execution_chart"
                                     widget="boolean_toggle"
                                     nolabel="1"
+                                    options="{'autosave': False}"
                                 />
                                 <label
                                     for="show_execution_chart"


### PR DESCRIPTION
When we autosave with the toggle button, the buffer chart is rendered 2 times. Otherwise, bypassing autosave renders only once.

Source: https://github.com/odoo/odoo/commit/a401b90ecabf02839c440a50d7004c04676a20d0