### PR TITLE
[16.0][FIX] ddmrp: Reduce the size of demand and supply charts

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -837,7 +837,7 @@ class StockBuffer(models.Model):
                 y_mrp = list(mrp_data.values())
 
                 p = figure(
-                    frame_width=500,
+                    frame_width=450,
                     frame_height=400,
                     y_axis_label="Quantity",
                     x_axis_type="datetime",
@@ -903,7 +903,7 @@ class StockBuffer(models.Model):
                 y_supply = list(supply_data.values())
 
                 p = figure(
-                    frame_width=500,
+                    frame_width=450,
                     frame_height=400,
                     y_axis_label="Quantity",
                     x_axis_type="datetime",

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -477,7 +477,6 @@
                                     <div style="margin-top: 1em;">
                                         <field
                                             name="ddmrp_supply_chart"
-                                            style="height:400px"
                                             widget="bokeh_chart"
                                             nolabel="1"
                                         />
@@ -487,7 +486,6 @@
                                     <div style="margin-top: 1em;">
                                         <field
                                             name="ddmrp_demand_chart"
-                                            style="height:400px"
                                             widget="bokeh_chart"
                                             nolabel="1"
                                         />


### PR DESCRIPTION
When we install ddmrp_chatter, the sheet size is reduced and charts are too wide. Reducing width it shows correctly with and without ddmrp_chatter.

Before the fix:
![image](https://github.com/OCA/ddmrp/assets/90243017/7301c5de-5aac-4700-95cf-354676104174)

After the fix: 
![image](https://github.com/OCA/ddmrp/assets/90243017/ed0d363a-3181-4231-99e4-4f66dce6babc)
