### PR TITLE
[16.0][FIX] ddmrp_product_replace: do not copy 'Considered as demand' field

### DIFF
--- a/ddmrp_product_replace/models/stock_buffer.py
+++ b/ddmrp_product_replace/models/stock_buffer.py
@@ -41,6 +41,7 @@ class StockBuffer(models.Model):
         string="Considered As Demand",
         help="This field is used for a correct product replacement within a "
         "DDMRP buffer.",
+        copy=False,
     )
     use_replacement_for_buffer_status = fields.Boolean(
         string="Include Incoming & On-Hands of replaced products",


### PR DESCRIPTION
This can leads to a wrong computation of e.g. the qualified demand.

Duplicating a buffer having 'Considered as demand' field set, and changing the product of the new buffer doesn't empty the 'Considered as demand' field, resulting with unrelated products that are taken into account in the computation of the qualified demand.

Forward port of #364 