### PR TITLE
[14.0][REF] ddmrp: Compute dlt depending on buffer location

### DIFF
--- a/ddmrp/__manifest__.py
+++ b/ddmrp/__manifest__.py
@@ -14,7 +14,6 @@
     "category": "Warehouse",
     "depends": [
         "purchase_stock",
-        "mrp_bom_location",
         "stock_demand_estimate",
         "web_widget_bokeh_chart",
         "mrp_multi_level",
@@ -51,6 +50,7 @@
         "data/ir_cron.xml",
         "wizards/ddmrp_duplicate_buffer.xml",
         "wizards/ddmrp_run_view.xml",
+        "wizards/mrp_bom_change_location.xml",
         "wizards/res_config_settings_views.xml",
     ],
     "demo": [

--- a/ddmrp/demo/mrp_bom_demo.xml
+++ b/ddmrp/demo/mrp_bom_demo.xml
@@ -4,14 +4,12 @@
     <record id="mrp_bom_fp01" model="mrp.bom">
         <field name="product_tmpl_id" ref="product_product_fp01_product_template" />
         <field name="product_uom_id" ref="uom.product_uom_unit" />
-        <field name="location_id" ref="stock.stock_location_stock" />
         <field name="sequence">5</field>
     </record>
     <record id="mrp_bom_fp01_line_as01" model="mrp.bom.line">
         <field name="product_id" ref="product_product_as01" />
         <field name="product_qty">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit" />
-        <field name="location_id" ref="stock.stock_location_stock" />
         <field name="sequence">5</field>
         <field name="bom_id" ref="mrp_bom_fp01" />
     </record>
@@ -19,7 +17,6 @@
     <record id="mrp_bom_as01" model="mrp.bom">
         <field name="product_tmpl_id" ref="product_product_as01_product_template" />
         <field name="product_uom_id" ref="uom.product_uom_unit" />
-        <field name="location_id" ref="stock.stock_location_stock" />
         <field name="sequence">5</field>
     </record>
     <record id="mrp_bom_as01_line_rm01" model="mrp.bom.line">
@@ -27,7 +24,6 @@
         <field name="product_qty">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit" />
         <field name="sequence">5</field>
-        <field name="location_id" ref="stock.stock_location_stock" />
         <field name="bom_id" ref="mrp_bom_as01" />
     </record>
     <record id="mrp_bom_as01_line_rm02" model="mrp.bom.line">
@@ -35,7 +31,6 @@
         <field name="product_qty">1</field>
         <field name="product_uom_id" ref="uom.product_uom_unit" />
         <field name="sequence">10</field>
-        <field name="location_id" ref="stock.stock_location_stock" />
         <field name="bom_id" ref="mrp_bom_as01" />
     </record>
 </odoo>

--- a/ddmrp/models/mrp_bom.py
+++ b/ddmrp/models/mrp_bom.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -25,20 +25,28 @@ class MrpBom(models.Model):
         string="Decoupled Lead Time (days)",
         compute="_compute_dlt",
     )
+    context_location_id = fields.Many2one(
+        comodel_name="stock.location",
+        string="Stock Location",
+        compute="_compute_context_location",
+    )
+    # This is a legacy field that can be removed in v17
+    location_id = fields.Many2one(related="context_location_id")
 
     def _get_search_buffer_domain(self):
         product = self.product_id
         if not product:
             if self.product_tmpl_id.product_variant_ids:
                 product = self.product_tmpl_id.product_variant_ids[0]
-        domain = [("product_id", "=", product.id)]
-        if self.location_id:
-            domain.append(("location_id", "=", self.location_id.id))
+        domain = [
+            ("product_id", "=", product.id),
+            ("location_id", "=", self.context_location_id.id),
+        ]
         if self.company_id:
             domain.append(("company_id", "=", self.company_id.id))
         return domain
 
-    @api.depends("product_id", "product_tmpl_id", "location_id")
+    @api.depends("product_id", "product_tmpl_id", "context_location_id")
     def _compute_buffer(self):
         for record in self:
             domain = record._get_search_buffer_domain()
@@ -54,6 +62,17 @@ class MrpBom(models.Model):
         for bom in self:
             bom.is_buffered = True if bom.buffer_id else False
 
+    def _compute_context_location(self):
+        for rec in self:
+            if self.env.context.get("location_id", None):
+                rec.context_location_id = self.env.context.get("location_id")
+            else:
+                company_id = rec.company_id or self.env.company
+                warehouse_id = self.env["stock.warehouse"].search(
+                    [("company_id", "=", company_id.id)], limit=1
+                )
+                rec.context_location_id = warehouse_id.lot_stock_id.id
+
     def _get_produce_delay(self):
         self.ensure_one()
         return self.product_id.produce_delay or self.product_tmpl_id.produce_delay
@@ -68,11 +87,11 @@ class MrpBom(models.Model):
                 i += 1
             elif line.product_id.bom_ids:
                 # If the a component is manufactured we continue exploding.
-                location = line.location_id
+                location = line.context_location_id
                 line_boms = line.product_id.bom_ids
                 bom = line_boms.filtered(
-                    lambda bom: bom.location_id == location
-                ) or line_boms.filtered(lambda bom: not bom.location_id)
+                    lambda bom: bom.context_location_id == location
+                ) or line_boms.filtered(lambda bom: not bom.context_location_id)
                 if bom:
                     paths[i] += bom[0]._get_produce_delay()
                     paths[i] += bom[0]._get_longest_path()
@@ -106,6 +125,15 @@ class MrpBom(models.Model):
         for rec in self:
             rec.dlt = rec._get_manufactured_dlt()
 
+    def action_change_context_location(self):
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("Change MRP BoM Location"),
+            "res_model": "mrp.bom.change.location",
+            "view_mode": "form",
+            "target": "new",
+        }
+
 
 class MrpBomLine(models.Model):
     _inherit = "mrp.bom.line"
@@ -124,12 +152,16 @@ class MrpBomLine(models.Model):
         string="Decoupled Lead Time (days)",
         compute="_compute_dlt",
     )
+    context_location_id = fields.Many2one(related="bom_id.context_location_id")
+    # This is a legacy field that can be removed in v17
+    location_id = fields.Many2one(related="context_location_id")
 
     def _get_search_buffer_domain(self):
         product = self.product_id or self.product_tmpl_id.product_variant_ids[0]
-        domain = [("product_id", "=", product.id)]
-        if self.location_id:
-            domain.append(("location_id", "=", self.location_id.id))
+        domain = [
+            ("product_id", "=", product.id),
+            ("location_id", "=", self.context_location_id.id),
+        ]
         if self.company_id:
             domain.append(("company_id", "=", self.company_id.id))
         return domain

--- a/ddmrp/models/mrp_bom.py
+++ b/ddmrp/models/mrp_bom.py
@@ -1,4 +1,4 @@
-# Copyright 2017-20 ForgeFlow S.L. (http://www.forgeflow.com)
+# Copyright 2017-24 ForgeFlow S.L. (http://www.forgeflow.com)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 import logging
@@ -62,6 +62,7 @@ class MrpBom(models.Model):
         for bom in self:
             bom.is_buffered = True if bom.buffer_id else False
 
+    @api.depends_context("location_id")
     def _compute_context_location(self):
         for rec in self:
             if self.env.context.get("location_id", None):
@@ -121,6 +122,8 @@ class MrpBom(models.Model):
         dlt += self._get_longest_path()
         return dlt
 
+    @api.depends("context_location_id")
+    @api.depends_context("location_id")
     def _compute_dlt(self):
         for rec in self:
             rec.dlt = rec._get_manufactured_dlt()
@@ -166,6 +169,8 @@ class MrpBomLine(models.Model):
             domain.append(("company_id", "=", self.company_id.id))
         return domain
 
+    @api.depends("context_location_id")
+    @api.depends_context("location_id")
     def _compute_is_buffered(self):
         for line in self:
             domain = line._get_search_buffer_domain()

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -234,6 +234,7 @@ class StockBuffer(models.Model):
         action = self.product_id.action_view_bom()
         boms = self._get_manufactured_bom(limit=100)
         action["domain"] = [("id", "in", boms.ids)]
+        action["context"] = {"location_id": self.location_id.id}
         return action
 
     @api.constrains("product_id")
@@ -924,17 +925,11 @@ class StockBuffer(models.Model):
             rec.order_spike_threshold = 0.5 * rec.red_zone_qty
 
     def _get_manufactured_bom(self, limit=1):
-        locations = self.env["stock.location"].search(
-            [("id", "child_of", [self.location_id.id])]
-        )
         return self.env["mrp.bom"].search(
             [
                 "|",
                 ("product_id", "=", self.product_id.id),
                 ("product_tmpl_id", "=", self.product_id.product_tmpl_id.id),
-                "|",
-                ("location_id", "in", locations.ids),
-                ("location_id", "=", False),
                 "|",
                 ("company_id", "=", self.company_id.id),
                 ("company_id", "=", False),
@@ -947,7 +942,7 @@ class StockBuffer(models.Model):
         for rec in self:
             if rec.buffer_profile_id.item_type == "manufactured":
                 bom = rec._get_manufactured_bom()
-                dlt = bom.dlt
+                dlt = bom.with_context(location_id=rec.location_id.id).dlt
             elif rec.buffer_profile_id.item_type == "distributed":
                 dlt = rec.lead_days
             else:

--- a/ddmrp/report/mrp_report_bom_structure.xml
+++ b/ddmrp/report/mrp_report_bom_structure.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <template
-        id="report_mrpbomstructure_ddmrp"
-        inherit_id="mrp_bom_location.report_mrpbomstructure_location"
-    >
+    <template id="report_mrpbomstructure_ddmrp" inherit_id="mrp.report_mrp_bom">
         <xpath expr="//thead/tr/th[last()]" position="before">
             <th
                 t-if="data['report_structure'] != 'bom_cost'"
@@ -49,10 +46,7 @@
             </td>
         </xpath>
     </template>
-    <template
-        id="report_mrp_bom_line"
-        inherit_id="mrp_bom_location.report_mrp_bom_line"
-    >
+    <template id="report_mrp_bom_line" inherit_id="mrp.report_mrp_bom_line">
         <xpath expr="//tr/td[last()]" position="before">
             <td class="o_mrp_prod_cost text-right">
                 <span>
@@ -87,10 +81,7 @@
             </span>
         </xpath>
     </template>
-    <template
-        id="report_mrp_bom_pdf_line"
-        inherit_id="mrp_bom_location.report_mrp_bom_pdf_line"
-    >
+    <template id="report_mrp_bom_pdf_line" inherit_id="mrp.report_mrp_bom_pdf_line">
         <xpath expr="//tr" position="inside">
             <t t-if="l['type'] == 'bom'">
                 <td

--- a/ddmrp/security/ir.model.access.csv
+++ b/ddmrp/security/ir.model.access.csv
@@ -15,6 +15,8 @@ access_stock_buffer_procurements_item,stock.buffer.procurements.item.user,model_
 access_stock_buffer_procurements_item_manager,stock.buffer.procurements.item.manager,model_make_procurement_buffer_item,stock.group_stock_manager,1,1,1,1
 access_ddmrp_duplicate_buffer,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffer,stock.group_stock_user,1,0,0,0
 access_ddmrp_duplicate_buffer_manager,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffer,ddmrp.group_stock_buffer_maintainer,1,1,1,1
+access_mrp_bom_change_location,mrp.bom.change.location,model_mrp_bom_change_location,stock.group_stock_user,1,0,0,0
+access_mrp_bom_change_location_manager,mrp.bom.change.location,model_mrp_bom_change_location,stock.group_stock_manager,1,1,1,1
 ddmrp_access_run,ddmrp.run,model_ddmrp_run,stock.group_stock_user,1,0,0,0
 ddmrp_access_run_manager,ddmrp.run.manager,model_ddmrp_run,stock.group_stock_manager,1,1,1,1
 access_ddmrp_mrp_move,mrp.move ddmrp,mrp_multi_level.model_mrp_move,stock.group_stock_user,1,0,0,0

--- a/ddmrp/security/ir.model.access.csv
+++ b/ddmrp/security/ir.model.access.csv
@@ -15,8 +15,7 @@ access_stock_buffer_procurements_item,stock.buffer.procurements.item.user,model_
 access_stock_buffer_procurements_item_manager,stock.buffer.procurements.item.manager,model_make_procurement_buffer_item,stock.group_stock_manager,1,1,1,1
 access_ddmrp_duplicate_buffer,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffer,stock.group_stock_user,1,0,0,0
 access_ddmrp_duplicate_buffer_manager,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffer,ddmrp.group_stock_buffer_maintainer,1,1,1,1
-access_mrp_bom_change_location,mrp.bom.change.location,model_mrp_bom_change_location,stock.group_stock_user,1,0,0,0
-access_mrp_bom_change_location_manager,mrp.bom.change.location,model_mrp_bom_change_location,stock.group_stock_manager,1,1,1,1
+access_mrp_bom_change_location_manager,mrp.bom.change.location,model_mrp_bom_change_location,stock.group_stock_user,1,1,1,1
 ddmrp_access_run,ddmrp.run,model_ddmrp_run,stock.group_stock_user,1,0,0,0
 ddmrp_access_run_manager,ddmrp.run.manager,model_ddmrp_run,stock.group_stock_manager,1,1,1,1
 access_ddmrp_mrp_move,mrp.move ddmrp,mrp_multi_level.model_mrp_move,stock.group_stock_user,1,0,0,0

--- a/ddmrp/static/description/index.html
+++ b/ddmrp/static/description/index.html
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/ddmrp/static/src/js/mrp_bom_report.js
+++ b/ddmrp/static/src/js/mrp_bom_report.js
@@ -1,0 +1,33 @@
+odoo.define("ddmrp.mrp_bom_report", function (require) {
+    "use strict";
+
+    var core = require("web.core");
+    var MrpBomReport = require("mrp.mrp_bom_report");
+
+    var DdmrpBomReport = MrpBomReport.extend({
+        init: function (parent, action) {
+            this._super.apply(this, arguments);
+            this.given_context.location_id = action.context.location_id || false;
+        },
+        get_bom: function (event) {
+            var self = this;
+            var $parent = $(event.currentTarget).closest("tr");
+            var activeID = $parent.data("id");
+            var productID = $parent.data("product_id");
+            var lineID = $parent.data("line");
+            var qty = $parent.data("qty");
+            var level = $parent.data("level") || 0;
+            return this._rpc({
+                model: "report.mrp.report_bom_structure",
+                method: "get_bom",
+                args: [activeID, productID, parseFloat(qty), lineID, level + 1],
+                context: this.given_context,
+            }).then(function (result) {
+                self.render_html(event, $parent, result);
+            });
+        },
+    });
+
+    core.action_registry.add("mrp_bom_report", DdmrpBomReport);
+    return DdmrpBomReport;
+});

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -1027,6 +1027,12 @@ class TestDdmrp(TestDdmrpCommon):
         self.assertEqual(len(bom_fp01.bom_line_ids), 1)
         self.assertEqual(bom_fp01.bom_line_ids.is_buffered, True)
         self.assertEqual(bom_fp01.bom_line_ids.buffer_id, buffer_as01)
+        # Check at the same time the DLT of 2 buffers using the same bom:
+        buffers = buffer1_fp01 + buffer2_fp01
+        buffers.invalidate_cache()
+        buffers._compute_dlt()
+        self.assertEqual(buffer1_fp01.dlt, 22)
+        self.assertEqual(buffer2_fp01.dlt, 2)
 
     def test_40_bokeh_charts(self):
         """Check bokeh chart computation."""

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -436,7 +436,6 @@ class TestDdmrp(TestDdmrpCommon):
     def _check_red_zone(
         self, orderpoint, red_base_qty=0.0, red_safety_qty=0.0, red_zone_qty=0.0
     ):
-
         # red base_qty = dlt * adu * lead time factor
         self.assertEqual(orderpoint.red_base_qty, red_base_qty)
 
@@ -447,7 +446,6 @@ class TestDdmrp(TestDdmrpCommon):
         self.assertEqual(orderpoint.red_zone_qty, red_zone_qty)
 
     def _check_yellow_zone(self, orderpoint, yellow_zone_qty=0.0, top_of_yellow=0.0):
-
         # yellow_zone_qty = dlt * adu
         self.assertEqual(orderpoint.yellow_zone_qty, yellow_zone_qty)
 
@@ -463,7 +461,6 @@ class TestDdmrp(TestDdmrpCommon):
         green_zone_qty=0.0,
         top_of_green=0.0,
     ):
-
         # green_zone_oc = order_cycle * adu
         self.assertEqual(orderpoint.green_zone_oc, green_zone_oc)
 
@@ -853,7 +850,7 @@ class TestDdmrp(TestDdmrpCommon):
                 "adu_calculation_method": self.adu_fixed.id,
             }
         )
-        self.bom_a.location_id = self.supplier_location.id
+        self.bom_a.context_location_id = self.supplier_location.id
         self.assertTrue(self.bom_a.is_buffered)
         self.assertEqual(self.bom_a.buffer_id, new_buffer)
         new_bom = self.env["mrp.bom"].create(
@@ -988,6 +985,48 @@ class TestDdmrp(TestDdmrpCommon):
         bom_line.invalidate_cache()
         self.assertTrue(bom_line.is_buffered)
         self.assertEqual(bom_line.buffer_id, component_buffer)
+
+    def test_38_bom_dlt_computation_multi_location(self):
+        """
+        If AS01 bom has no location it means that it can be manufactured
+        in more than one location.
+        """
+        bom_fp01 = self.env.ref("ddmrp.mrp_bom_fp01")
+        buffer1_fp01 = self.env.ref("ddmrp.stock_buffer_fp01")
+        self.assertEqual(bom_fp01.dlt, 22.0)
+        self.assertEqual(bom_fp01.buffer_id, buffer1_fp01)
+        self.assertEqual(len(bom_fp01.bom_line_ids), 1)
+        self.assertEqual(bom_fp01.bom_line_ids.is_buffered, False)
+        # Now create buffers in another location and check in that context
+        product_fp01 = self.env.ref("ddmrp.product_product_fp01")
+        product_as01 = self.env.ref("ddmrp.product_product_as01")
+        buffer2_fp01 = self.bufferModel.create(
+            {
+                "buffer_profile_id": self.buffer_profile_mmm.id,
+                "product_id": product_fp01.id,
+                "warehouse_id": self.warehouse.id,
+                "location_id": self.supplier_location.id,
+                "adu_calculation_method": self.adu_fixed.id,
+            }
+        )
+        buffer_as01 = self.bufferModel.create(
+            {
+                "buffer_profile_id": self.buffer_profile_mmm.id,
+                "product_id": product_as01.id,
+                "warehouse_id": self.warehouse.id,
+                "location_id": self.supplier_location.id,
+                "adu_calculation_method": self.adu_fixed.id,
+            }
+        )
+        bom_fp01.context_location_id = self.supplier_location.id
+        bom_fp01.bom_line_ids._compute_is_buffered()
+        bom_fp01._compute_dlt()
+        bom_fp01.bom_line_ids._compute_dlt()
+        self.assertEqual(bom_fp01.dlt, 2.0)
+        self.assertEqual(bom_fp01.buffer_id, buffer2_fp01)
+        self.assertEqual(len(bom_fp01.bom_line_ids), 1)
+        self.assertEqual(bom_fp01.bom_line_ids.is_buffered, True)
+        self.assertEqual(bom_fp01.bom_line_ids.buffer_id, buffer_as01)
 
     def test_40_bokeh_charts(self):
         """Check bokeh chart computation."""

--- a/ddmrp/views/ddmrp_assets_backend.xml
+++ b/ddmrp/views/ddmrp_assets_backend.xml
@@ -10,6 +10,10 @@
                 type="text/javascript"
                 src="/ddmrp/static/src/js/list_renderer_buffer_info.js"
             />
+            <script
+                type="text/javascript"
+                src="/ddmrp/static/src/js/mrp_bom_report.js"
+            />
             <link
                 rel="stylesheet"
                 type="text/scss"

--- a/ddmrp/views/mrp_bom_view.xml
+++ b/ddmrp/views/mrp_bom_view.xml
@@ -7,10 +7,20 @@
         <field name="model">mrp.bom</field>
         <field name="inherit_id" ref="mrp.mrp_bom_form_view" />
         <field name="arch" type="xml">
-            <field name="location_id" position="after">
+            <field name="product_id" position="after">
                 <field name="is_buffered" />
                 <field name="buffer_id" />
-                <field name="dlt" />
+                <label for="dlt" />
+                <div class="o_row">
+                    <field name="dlt" />
+                     (<field name="context_location_id" options="{'no_open': True}" />)
+                    <button
+                        title="Change Location"
+                        name="action_change_context_location"
+                        icon="fa-exchange"
+                        type="object"
+                    />
+                </div>
             </field>
             <xpath
                 expr="//field[@name='bom_line_ids']/tree/field[@name='product_uom_id']"
@@ -19,6 +29,7 @@
                 <field name="is_buffered" />
                 <field name="buffer_id" />
                 <field name="dlt" />
+                <field name="context_location_id" />
             </xpath>
         </field>
     </record>

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -670,6 +670,7 @@
         <field name="name">Stock Buffers</field>
         <field name="res_model">stock.buffer</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'location_id': False}</field>
     </record>
     <menuitem
         id="menu_stock_buffer"

--- a/ddmrp/wizards/__init__.py
+++ b/ddmrp/wizards/__init__.py
@@ -1,5 +1,6 @@
 from . import multi_level_mrp
 from . import make_procurement_buffer
+from . import mrp_bom_change_location
 from . import ddmrp_duplicate_buffer
 from . import ddmrp_run
 from . import res_config_settings

--- a/ddmrp/wizards/mrp_bom_change_location.py
+++ b/ddmrp/wizards/mrp_bom_change_location.py
@@ -1,0 +1,42 @@
+# Copyright 2023 ForgeFlow S.L. (http://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, fields, models
+
+
+class MrpBomChangeLocation(models.TransientModel):
+    _name = "mrp.bom.change.location"
+    _description = "MRP Bom Change Location"
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        bom_obj = self.env["mrp.bom"]
+        bom_id = self.env.context.get("active_id", False)
+        active_model = self.env.context["active_model"]
+
+        if not bom_id:
+            return
+        assert active_model == "mrp.bom", "Bad context propagation"
+
+        bom = bom_obj.browse(bom_id)
+        res.update(
+            {
+                "location_id": bom.context_location_id.id,
+            }
+        )
+        return res
+
+    location_id = fields.Many2one(
+        comodel_name="stock.location",
+    )
+
+    def action_change_location(self):
+        bom_id = self.env.context.get("active_id", False)
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": "mrp.bom",
+            "view_mode": "form",
+            "res_id": bom_id,
+            "context": {"location_id": self.location_id.id},
+        }

--- a/ddmrp/wizards/mrp_bom_change_location.xml
+++ b/ddmrp/wizards/mrp_bom_change_location.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="mrp_bom_change_location_wizard" model="ir.ui.view">
+        <field name="name">Mrp Bom Change Location Wizard</field>
+        <field name="model">mrp.bom.change.location</field>
+        <field name="arch" type="xml">
+            <form string="Change Mrp Bom Location">
+                <group>
+                    <group>
+                        <field name="location_id" />
+                    </group>
+                </group>
+                <footer>
+                    <button
+                        name="action_change_location"
+                        string="Change"
+                        type="object"
+                        class="btn-primary"
+                    />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>

--- a/ddmrp/wizards/mrp_bom_change_location.xml
+++ b/ddmrp/wizards/mrp_bom_change_location.xml
@@ -5,7 +5,12 @@
         <field name="name">Mrp Bom Change Location Wizard</field>
         <field name="model">mrp.bom.change.location</field>
         <field name="arch" type="xml">
-            <form string="Change Mrp Bom Location">
+            <form string="Change Bom Location">
+                <p class="oe_grey">
+                    Change the inventory location that it is considered to compute when a product is buffered or not.
+                    This can potentially change the Decoupled Lead Time (DLT) value.
+                    This change is only informative and won't affect any process or buffer size or recommendations.
+                </p>
                 <group>
                     <group>
                         <field name="location_id" />


### PR DESCRIPTION
When we compute DLT for manufactured buffers, we need to consider the location from where we are computing. If the buffered products change between one location and another, the DLTs will be different.


https://github.com/OCA/ddmrp/assets/90243017/0e46692d-4b84-4d9c-a38e-fdab8c5c82dd


Comments:
- Which location should have priority, the location of the BoM or the one passed by context? 
- It would be nice to add a feature in the BoM form that allows to change the context location.