### PR TITLE
[13.0][IMP] ddmrp: resize top yellow of execution chart

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -689,8 +689,8 @@ class StockBuffer(models.Model):
             self.top_of_red + self.green_zone_qty,
             precision_rounding=self.product_uom.rounding,
         )
-        toy2_exec = self.top_of_yellow
         tor2_exec = self.top_of_green
+        toy2_exec = (tor2_exec + tog_exec) / 2
         hex_colors = self._get_colors_hex_map(pallete="execution")
         red = p.vbar(
             x=1,


### PR DESCRIPTION
Resize the top yellow of the execution chart to share half of the top zone with the red zone. This fixes the case when the green zone is big enough to consume entirely the top yellow zone.