### PR TITLE
[13.0][IMP] ddmrp_history: resize top yellow zone on historic execution chart

### DIFF
--- a/ddmrp_history/models/stock_buffer.py
+++ b/ddmrp_history/models/stock_buffer.py
@@ -201,16 +201,18 @@ class StockBuffer(models.Model):
             data[categories[2]] = [(r.top_of_red / 2) for r in history]
             data[categories[3]] = [r.top_of_green - r.top_of_yellow for r in history]
             data[categories[4]] = [
-                r.top_of_yellow - r.top_of_red - (r.top_of_green - r.top_of_yellow)
+                (r.top_of_green - r.top_of_red - (r.top_of_green - r.top_of_yellow)) / 2
                 for r in history
             ]
-            data[categories[5]] = [r.top_of_green - r.top_of_yellow for r in history]
+            data[categories[5]] = [
+                (r.top_of_green - r.top_of_red - (r.top_of_green - r.top_of_yellow)) / 2
+                for r in history
+            ]
             data[categories[6]] = [
                 finish_stack
                 - r.top_of_red
                 - (r.top_of_green - r.top_of_yellow)
-                - (r.top_of_yellow - r.top_of_red - (r.top_of_green - r.top_of_yellow))
-                - (r.top_of_green - r.top_of_yellow)
+                - (r.top_of_green - r.top_of_red - (r.top_of_green - r.top_of_yellow))
                 for r in history
             ]
 


### PR DESCRIPTION
Resize the top yellow of the execution chart to share half of the top zone with the red zone. This fixes the case when the green zone is big enough to consume entirely the top yellow zone.

@ForgeFlow