### PR TITLE
[15.0][IMP] ddmrp and ddmrp_history: resize top yellow of execution chart

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -717,8 +717,8 @@ class StockBuffer(models.Model):
             self.top_of_red + self.green_zone_qty,
             precision_rounding=self.product_uom.rounding,
         )
-        toy2_exec = self.top_of_yellow
         tor2_exec = self.top_of_green
+        toy2_exec = (tor2_exec + tog_exec) / 2
         hex_colors = self._get_colors_hex_map(pallete="execution")
         red = p.vbar(
             x=1,

--- a/ddmrp_history/models/stock_buffer.py
+++ b/ddmrp_history/models/stock_buffer.py
@@ -215,16 +215,18 @@ class StockBuffer(models.Model):
             data[categories[2]] = [(r.top_of_red / 2) for r in history]
             data[categories[3]] = [r.top_of_green - r.top_of_yellow for r in history]
             data[categories[4]] = [
-                r.top_of_yellow - r.top_of_red - (r.top_of_green - r.top_of_yellow)
+                (r.top_of_green - r.top_of_red - (r.top_of_green - r.top_of_yellow)) / 2
                 for r in history
             ]
-            data[categories[5]] = [r.top_of_green - r.top_of_yellow for r in history]
+            data[categories[5]] = [
+                (r.top_of_green - r.top_of_red - (r.top_of_green - r.top_of_yellow)) / 2
+                for r in history
+            ]
             data[categories[6]] = [
                 finish_stack
                 - r.top_of_red
                 - (r.top_of_green - r.top_of_yellow)
-                - (r.top_of_yellow - r.top_of_red - (r.top_of_green - r.top_of_yellow))
-                - (r.top_of_green - r.top_of_yellow)
+                - (r.top_of_green - r.top_of_red - (r.top_of_green - r.top_of_yellow))
                 for r in history
             ]
 


### PR DESCRIPTION
Resize the top yellow of the execution chart to share half of the top zone with the red zone. This fixes the case when the green zone is big enough to consume entirely the top yellow zone.

fwport https://github.com/OCA/ddmrp/pull/374 and https://github.com/OCA/ddmrp/pull/375