### PR TITLE
[15.0][FIX] ddmrp: user without access to manufacturing app to update buffers

### DIFF
--- a/ddmrp/security/ir.model.access.csv
+++ b/ddmrp/security/ir.model.access.csv
@@ -17,3 +17,4 @@ access_ddmrp_duplicate_buffer,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffe
 access_ddmrp_duplicate_buffer_manager,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffer,stock.group_stock_manager,1,1,1,1
 ddmrp_access_run,ddmrp.run,model_ddmrp_run,stock.group_stock_user,1,0,0,0
 ddmrp_access_run_manager,ddmrp.run.manager,model_ddmrp_run,stock.group_stock_manager,1,1,1,1
+access_ddmrp_mrp_move,mrp.move ddmrp,mrp_multi_level.model_mrp_move,stock.group_stock_user,1,0,0,0


### PR DESCRIPTION
Acces to mrp.move is needed to refresh a stock buffer

Backport of #389 