### PR TITLE
[14.0][FIX] ddmrp: Remove mrp_move from qualified demand calculation

### DIFF
--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -430,23 +430,12 @@
                                         name="qualified_demand_stock_move_ids"
                                         invisible="1"
                                     />
-                                    <field
-                                        name="qualified_demand_mrp_move_ids"
-                                        invisible="1"
-                                    />
                                     <button
                                         title="View Qualified Demand from Pickings"
                                         name="action_view_qualified_demand_pickings"
                                         icon="fa-search"
                                         type="object"
                                         attrs="{'invisible': ['|', ('qualified_demand', '=', 0), ('qualified_demand_stock_move_ids', '=', [])]}"
-                                    />
-                                    <button
-                                        title="View Qualified Demand from MRP"
-                                        name="action_view_qualified_demand_mrp"
-                                        icon="fa-search"
-                                        type="object"
-                                        attrs="{'invisible': ['|', ('qualified_demand', '=', 0), ('qualified_demand_mrp_move_ids', '=', [])]}"
                                     />
                                 </div>
                                 <field name="net_flow_position" />


### PR DESCRIPTION
Qualified demand should only consider actual demand, such as outgoing stock moves or any entity that refers to something confirmed and real. MRP Move is an entity similar to Stock Demand Estimate where we forecast future demand and should not be considered as qualified demand.

Stock buffers should consider forecasted future demand via the ADU calculation, sizing the buffer according to that demand. But, then, only at the moment that this demand is confirmed it should be considered as qualified demand.