### PR TITLE
[14.0] ddmrp: fix duplicating buffer access right

### DIFF
--- a/ddmrp/security/ir.model.access.csv
+++ b/ddmrp/security/ir.model.access.csv
@@ -14,7 +14,7 @@ access_stock_buffer_procurements_manager,stock.buffer.procurements.manager,model
 access_stock_buffer_procurements_item,stock.buffer.procurements.item.user,model_make_procurement_buffer_item,stock.group_stock_user,1,0,0,0
 access_stock_buffer_procurements_item_manager,stock.buffer.procurements.item.manager,model_make_procurement_buffer_item,stock.group_stock_manager,1,1,1,1
 access_ddmrp_duplicate_buffer,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffer,stock.group_stock_user,1,0,0,0
-access_ddmrp_duplicate_buffer_manager,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffer,stock.group_stock_manager,1,1,1,1
+access_ddmrp_duplicate_buffer_manager,ddmrp.duplicate.buffer,model_ddmrp_duplicate_buffer,ddmrp.group_stock_buffer_maintainer,1,1,1,1
 ddmrp_access_run,ddmrp.run,model_ddmrp_run,stock.group_stock_user,1,0,0,0
 ddmrp_access_run_manager,ddmrp.run.manager,model_ddmrp_run,stock.group_stock_manager,1,1,1,1
 access_ddmrp_mrp_move,mrp.move ddmrp,mrp_multi_level.model_mrp_move,stock.group_stock_user,1,0,0,0


### PR DESCRIPTION
As `ddmrp.duplicate.buffer` is a helper to create new buffers from existing ones, its access rights should be the same than `stock.buffer`.

Makes the duplicate buffer wizard usable by "Stock Buffer Maintainer" group.

cc @LoisRForgeFlow @BernatPForgeFlow 