### PR TITLE
[14.0] ddmrp_adjustment: keep RO access for 'Inventory / User' group

### DIFF
--- a/ddmrp_adjustment/security/ir.model.access.csv
+++ b/ddmrp_adjustment/security/ir.model.access.csv
@@ -1,9 +1,11 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 ddmrp_adjustment_access_user,ddmrp.adjustment.user,model_ddmrp_adjustment,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_manager,ddmrp.adjustment.manager,model_ddmrp_adjustment,ddmrp.group_ddmrp_manager,1,1,1,1
+ddmrp_adjustment_access_buffer_maintainer,ddmrp.adjustment.buffer.maintainer,model_ddmrp_adjustment,ddmrp.group_stock_buffer_maintainer,1,1,1,1
 ddmrp_adjustment_access_sheet_manager,ddmrp.adjustment.sheet.manager,model_ddmrp_adjustment_sheet,ddmrp.group_ddmrp_manager,1,1,1,1
 ddmrp_adjustment_access_sheet_buffer_maintainer,ddmrp.adjustment.sheet.buffer.maintainer,model_ddmrp_adjustment_sheet,ddmrp.group_stock_buffer_maintainer,1,1,1,1
 ddmrp_adjustment_access_sheet_line_manager,ddmrp.adjustment.sheet.line.manager,model_ddmrp_adjustment_sheet_line,ddmrp.group_ddmrp_manager,1,1,1,1
 ddmrp_adjustment_access_sheet_line_buffer_maintainer,ddmrp.adjustment.sheet.line.buffer.maintainer,model_ddmrp_adjustment_sheet_line,ddmrp.group_stock_buffer_maintainer,1,1,1,1
 ddmrp_adjustment_access_demand_user,ddmrp.adjustment.demand.user,model_ddmrp_adjustment_demand,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_demand_manager,ddmrp.adjustment.demand.manager,model_ddmrp_adjustment_demand,ddmrp.group_ddmrp_manager,1,1,1,1
+ddmrp_adjustment_access_demand_buffer_maintainer,ddmrp.adjustment.buffer.maintainer,model_ddmrp_adjustment_demand,ddmrp.group_stock_buffer_maintainer,1,1,1,1

--- a/ddmrp_adjustment/security/ir.model.access.csv
+++ b/ddmrp_adjustment/security/ir.model.access.csv
@@ -1,9 +1,9 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-ddmrp_adjustment_access_user,ddmrp.adjustment.user,model_ddmrp_adjustment,ddmrp.group_stock_buffer_maintainer,1,0,0,0
+ddmrp_adjustment_access_user,ddmrp.adjustment.user,model_ddmrp_adjustment,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_manager,ddmrp.adjustment.manager,model_ddmrp_adjustment,ddmrp.group_ddmrp_manager,1,1,1,1
-ddmrp_adjustment_access_sheet_user,ddmrp.adjustment.sheet.user,model_ddmrp_adjustment_sheet,ddmrp.group_stock_buffer_maintainer,1,0,0,0
+ddmrp_adjustment_access_sheet_user,ddmrp.adjustment.sheet.user,model_ddmrp_adjustment_sheet,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_sheet_manager,ddmrp.adjustment.sheet.manager,model_ddmrp_adjustment_sheet,ddmrp.group_ddmrp_manager,1,1,1,1
-ddmrp_adjustment_access_sheet_line_user,ddmrp.adjustment.sheet.line.user,model_ddmrp_adjustment_sheet_line,ddmrp.group_stock_buffer_maintainer,1,0,0,0
+ddmrp_adjustment_access_sheet_line_user,ddmrp.adjustment.sheet.line.user,model_ddmrp_adjustment_sheet_line,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_sheet_line_manager,ddmrp.adjustment.sheet.line.manager,model_ddmrp_adjustment_sheet_line,ddmrp.group_ddmrp_manager,1,1,1,1
-ddmrp_adjustment_access_demand_user,ddmrp.adjustment.demand.user,model_ddmrp_adjustment_demand,ddmrp.group_stock_buffer_maintainer,1,0,0,0
+ddmrp_adjustment_access_demand_user,ddmrp.adjustment.demand.user,model_ddmrp_adjustment_demand,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_demand_manager,ddmrp.adjustment.demand.manager,model_ddmrp_adjustment_demand,ddmrp.group_ddmrp_manager,1,1,1,1

--- a/ddmrp_adjustment/security/ir.model.access.csv
+++ b/ddmrp_adjustment/security/ir.model.access.csv
@@ -1,9 +1,9 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 ddmrp_adjustment_access_user,ddmrp.adjustment.user,model_ddmrp_adjustment,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_manager,ddmrp.adjustment.manager,model_ddmrp_adjustment,ddmrp.group_ddmrp_manager,1,1,1,1
-ddmrp_adjustment_access_sheet_user,ddmrp.adjustment.sheet.user,model_ddmrp_adjustment_sheet,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_sheet_manager,ddmrp.adjustment.sheet.manager,model_ddmrp_adjustment_sheet,ddmrp.group_ddmrp_manager,1,1,1,1
-ddmrp_adjustment_access_sheet_line_user,ddmrp.adjustment.sheet.line.user,model_ddmrp_adjustment_sheet_line,stock.group_stock_user,1,0,0,0
+ddmrp_adjustment_access_sheet_buffer_maintainer,ddmrp.adjustment.sheet.buffer.maintainer,model_ddmrp_adjustment_sheet,ddmrp.group_stock_buffer_maintainer,1,1,1,1
 ddmrp_adjustment_access_sheet_line_manager,ddmrp.adjustment.sheet.line.manager,model_ddmrp_adjustment_sheet_line,ddmrp.group_ddmrp_manager,1,1,1,1
+ddmrp_adjustment_access_sheet_line_buffer_maintainer,ddmrp.adjustment.sheet.line.buffer.maintainer,model_ddmrp_adjustment_sheet_line,ddmrp.group_stock_buffer_maintainer,1,1,1,1
 ddmrp_adjustment_access_demand_user,ddmrp.adjustment.demand.user,model_ddmrp_adjustment_demand,stock.group_stock_user,1,0,0,0
 ddmrp_adjustment_access_demand_manager,ddmrp.adjustment.demand.manager,model_ddmrp_adjustment_demand,ddmrp.group_ddmrp_manager,1,1,1,1

--- a/ddmrp_adjustment/wizards/ddmrp_adjustment_wizard_view.xml
+++ b/ddmrp_adjustment/wizards/ddmrp_adjustment_wizard_view.xml
@@ -69,7 +69,7 @@
         id="menu_ddmrp_adjustment_sheet_wizard"
         parent="stock_demand_estimate.stock_demand_planning_menu"
         action="action_ddmrp_adjustment_sheet_wizard"
-        groups="stock.group_stock_manager"
+        groups="ddmrp.group_stock_buffer_maintainer"
         sequence="51"
     />
 </odoo>


### PR DESCRIPTION
As `Inventory / Users` have a read only access to buffers, should not we keep a RO access as well on `demand.adjustment`?

Currently a stock user is unable to open a buffer if `ddmrp_adjustment` is installed without being part of the `DDMRP / Stock Buffer Maintainer` group (which gives create/write access to buffers, not always what we want).

I cannot say about other data models, I let you check this (I revert the changes done [here](https://github.com/OCA/ddmrp/commit/53ffd4e4f3342d10e65a06df4aba2717762e44b0) on RO access rights) and will update my PR accordingly if needed.

Another question: is `DDMRP / DDMRP Manager` required to create adjustments (I'm not familiar with this feature, just wondering)?

cc @BernatPForgeFlow @LoisRForgeFlow 