### PR TITLE
[16.0][IMP] ddmrp: enable scheduler tasks

### DIFF
--- a/ddmrp/models/__init__.py
+++ b/ddmrp/models/__init__.py
@@ -15,3 +15,4 @@ from . import stock_move_line
 from . import stock_picking
 from . import res_company
 from . import product_product
+from . import stock_warehouse_orderpoint

--- a/ddmrp/models/mrp_production.py
+++ b/ddmrp/models/mrp_production.py
@@ -24,11 +24,11 @@ class MrpProduction(models.Model):
         string="On Hand/TOR (%)",
     )
 
-    @api.model
-    def create(self, vals):
-        record = super(MrpProduction, self).create(vals)
-        record._calc_execution_priority()
-        return record
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._calc_execution_priority()
+        return records
 
     def _calc_execution_priority(self):
         """Technical note: this method cannot be decorated with api.depends,

--- a/ddmrp/models/procurement_group.py
+++ b/ddmrp/models/procurement_group.py
@@ -9,13 +9,6 @@ from odoo import api, models
 class ProcurementGroup(models.Model):
     _inherit = "procurement.group"
 
-    @api.model
-    def _run_scheduler_tasks(self, use_new_cursor=False, company_id=False):
-        """Override the standard method to disable the possibility to
-        automatically procure from orderpoints and to automatically
-        reserve stock moves."""
-        return True
-
     # UOM: (stock_orderpoint_uom):
     @api.model
     def run(self, procurements, raise_user_error=True):

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1118,6 +1118,7 @@ class StockBuffer(models.Model):
         store=True,
     )
     top_of_red = fields.Float(
+        string="Top Of Red",
         related="red_zone_qty",
         store=True,
     )

--- a/ddmrp/models/stock_warehouse_orderpoint.py
+++ b/ddmrp/models/stock_warehouse_orderpoint.py
@@ -1,0 +1,30 @@
+# Copyright 2024 ForgeFlow S.L. (http://www.forgeflow.com)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, models
+
+
+class StockWarehouseOrderpoint(models.Model):
+    _inherit = "stock.warehouse.orderpoint"
+
+    def _get_orderpoint_action(self):
+        return super(
+            StockWarehouseOrderpoint, self.with_context(_from_get_op_action=True)
+        )._get_orderpoint_action()
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if self.env.context.get("_from_get_op_action"):
+            new_vals_list = []
+            for vals in vals_list:
+                buffer = self.env["stock.buffer"].search(
+                    [
+                        ("product_id", "=", vals.get("product_id")),
+                        ("location_id", "=", vals.get("location_id")),
+                    ],
+                    limit=1,
+                )
+                if not buffer:
+                    new_vals_list.append(vals)
+            vals_list = new_vals_list
+        return super().create(vals_list)

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -40,6 +40,7 @@ class TestDdmrpCommon(common.TransactionCase):
         cls.supinfo_model = cls.env["product.supplierinfo"]
         cls.pol_model = cls.env["purchase.order.line"]
         cls.wh_model = cls.env["stock.warehouse"]
+        cls.orderpoint_model = cls.env["stock.warehouse.orderpoint"]
 
         # Refs
         cls.main_company = cls.env.ref("base.main_company")
@@ -363,11 +364,13 @@ class TestDdmrpCommon(common.TransactionCase):
         )
         return user
 
-    def create_pickingoutA(self, date_move, qty):
+    def create_pickingoutA(self, date_move, qty, source_location=None):
+        if not source_location:
+            source_location = self.binA
         picking = self.pickingModel.with_user(self.user).create(
             {
                 "picking_type_id": self.picking_type_out.id,
-                "location_id": self.binA.id,
+                "location_id": source_location.id,
                 "location_dest_id": self.customer_location.id,
                 "scheduled_date": date_move,
                 "move_ids": [
@@ -380,7 +383,7 @@ class TestDdmrpCommon(common.TransactionCase):
                             "date": date_move,
                             "product_uom": self.productA.uom_id.id,
                             "product_uom_qty": qty,
-                            "location_id": self.binA.id,
+                            "location_id": source_location.id,
                             "location_dest_id": self.customer_location.id,
                         },
                     )
@@ -445,11 +448,13 @@ class TestDdmrpCommon(common.TransactionCase):
         picking.action_confirm()
         return picking
 
-    def create_picking_out(self, product, date_move, qty):
+    def create_picking_out(self, product, date_move, qty, source_location=None):
+        if not source_location:
+            source_location = self.binA
         picking = self.pickingModel.with_user(self.user).create(
             {
                 "picking_type_id": self.picking_type_out.id,
-                "location_id": self.binA.id,
+                "location_id": source_location.id,
                 "location_dest_id": self.customer_location.id,
                 "scheduled_date": date_move,
                 "move_ids": [
@@ -462,7 +467,7 @@ class TestDdmrpCommon(common.TransactionCase):
                             "date": date_move,
                             "product_uom": product.uom_id.id,
                             "product_uom_qty": qty,
-                            "location_id": self.binA.id,
+                            "location_id": source_location.id,
                             "location_dest_id": self.customer_location.id,
                         },
                     )

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -1238,3 +1238,51 @@ class TestDdmrp(TestDdmrpCommon):
         self.bufferModel.cron_ddmrp_adu()
         to_assert_value = 2 * 0.5 + 2 * 0.5
         self.assertEqual(self.buffer_a.adu, to_assert_value)
+
+    def test_46_disable_auto_create_orderpoint(self):
+        """If a product has a buffer, do not create a new orderpoint for same location"""
+        op_a = self.orderpoint_model.search(
+            [
+                ("product_id", "=", self.productA.id),
+                ("location_id", "=", self.stock_location.id),
+            ]
+        )
+        self.assertFalse(op_a)
+        nbp = self.productModel.create(
+            {
+                "name": "Non Buffered Product",
+                "standard_price": 1,
+                "type": "product",
+                "uom_id": self.uom_unit.id,
+                "default_code": "NBP",
+            }
+        )
+        op_nbp = self.orderpoint_model.search(
+            [
+                ("product_id", "=", nbp.id),
+                ("location_id", "=", self.stock_location.id),
+            ]
+        )
+        self.assertFalse(op_nbp)
+        # Create a negative projection for both products:
+        date_move = datetime.today()
+        self.create_pickingoutA(date_move, 500, source_location=self.stock_location)
+        self.create_picking_out(
+            nbp, date_move, 500, source_location=self.stock_location
+        )
+        # Access "Replenishment" menu
+        self.orderpoint_model.action_open_orderpoints()
+        op_a = self.orderpoint_model.search(
+            [
+                ("product_id", "=", self.productA.id),
+                ("location_id", "=", self.stock_location.id),
+            ]
+        )
+        self.assertFalse(op_a)
+        op_nbp = self.orderpoint_model.search(
+            [
+                ("product_id", "=", nbp.id),
+                ("location_id", "=", self.stock_location.id),
+            ]
+        )
+        self.assertTrue(op_nbp)


### PR DESCRIPTION
Scheduler task can reorder from orderpoints, so we also take care of disable auto reorderpoint creation for positions that already have a stock buffer. A test case is added too.