### PR TITLE
[16.0][FIX] ddmrp: incorrect handling of reservation UoM computing demand.

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1615,7 +1615,11 @@ class StockBuffer(models.Model):
             demand_by_days[move_date] = 0.0
         for move in moves:
             date = move.date.date()
-            demand_by_days[date] += move.product_qty - move.reserved_availability
+            demand_by_days[
+                date
+            ] += move.product_qty - move.product_uom._compute_quantity(
+                move.reserved_availability, move.product_id.uom_id
+            )
         return demand_by_days
 
     def _search_mrp_moves_qualified_demand_domain(self):

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -78,6 +78,7 @@ class TestDdmrpCommon(common.TransactionCase):
             }
         )
         cls.uom_unit = cls.env.ref("uom.product_uom_unit")
+        cls.dozen_unit = cls.env.ref("uom.product_uom_dozen")
         cls.buffer_profile_pur = cls.env.ref(
             "ddmrp.stock_buffer_profile_replenish_purchased_medium_medium"
         )
@@ -364,7 +365,9 @@ class TestDdmrpCommon(common.TransactionCase):
         )
         return user
 
-    def create_pickingoutA(self, date_move, qty, source_location=None):
+    def create_pickingoutA(self, date_move, qty, uom=False, source_location=None):
+        if not uom:
+            uom = self.productA.uom_id
         if not source_location:
             source_location = self.binA
         picking = self.pickingModel.with_user(self.user).create(
@@ -381,7 +384,7 @@ class TestDdmrpCommon(common.TransactionCase):
                             "name": "Test move",
                             "product_id": self.productA.id,
                             "date": date_move,
-                            "product_uom": self.productA.uom_id.id,
+                            "product_uom": uom.id,
                             "product_uom_qty": qty,
                             "location_id": source_location.id,
                             "location_dest_id": self.customer_location.id,


### PR DESCRIPTION
A new test case is added to highlight the problem.

Fwport of https://github.com/OCA/ddmrp/pull/302.