### PR TITLE
[16.0][IMP] ddmrp_adjustment: visualize parent DAFs

### DIFF
--- a/ddmrp_adjustment/models/ddmrp_adjustment_demand.py
+++ b/ddmrp_adjustment/models/ddmrp_adjustment_demand.py
@@ -16,6 +16,8 @@ class DdmrpAdjustmentDemand(models.Model):
     buffer_origin_id = fields.Many2one(
         comodel_name="stock.buffer",
         string="Originated from",
+        required=True,
+        ondelete="cascade",
     )
     product_origin_id = fields.Many2one(
         related="buffer_origin_id.product_id",

--- a/ddmrp_adjustment/models/stock_buffer.py
+++ b/ddmrp_adjustment/models/stock_buffer.py
@@ -26,12 +26,23 @@ class StockBuffer(models.Model):
     pre_daf_adu = fields.Float(readonly=True)
     daf_applied = fields.Float(default=-1, readonly=True)
     parent_daf_applied = fields.Float(default=-1, readonly=True)
+    count_ddmrp_adjustment_demand = fields.Integer(
+        compute="_compute_count_ddmrp_adjustment_demand"
+    )
+
+    def _compute_count_ddmrp_adjustment_demand(self):
+        for rec in self:
+            rec.count_ddmrp_adjustment_demand = len(
+                self.env["ddmrp.adjustment.demand"].search(
+                    [("buffer_origin_id", "=", rec.id)]
+                )
+            )
 
     @api.depends("daf_applied", "parent_daf_applied")
     def _compute_daf_text(self):
         for rec in self:
-            rec.daf_text = "DAF: *" + str(rec.daf_applied)
-            rec.parent_daf_text = "P. DAF: +" + str(rec.parent_daf_applied)
+            rec.daf_text = "DAF: *" + str(round(rec.daf_applied, 2))
+            rec.parent_daf_text = "P. DAF: +" + str(round(rec.parent_daf_applied, 2))
 
     def _daf_to_apply_domain(self, current=True):
         self.ensure_one()
@@ -49,6 +60,9 @@ class StockBuffer(models.Model):
         # Apply DAFs if existing for the buffer.
         res = super()._calc_adu()
         for rec in self:
+            self.env["ddmrp.adjustment.demand"].search(
+                [("buffer_origin_id", "=", rec.id)]
+            ).unlink()
             dafs_to_apply = self.env["ddmrp.adjustment"].search(
                 rec._daf_to_apply_domain()
             )
@@ -127,7 +141,6 @@ class StockBuffer(models.Model):
     def cron_ddmrp_adu(self, automatic=False):
         """Apply extra demand originated by Demand Adjustment Factors to
         components after the cron update of all the buffers."""
-        self.env["ddmrp.adjustment.demand"].search([]).unlink()
         res = super().cron_ddmrp_adu(automatic)
         today = fields.Date.today()
         for op in self.search([]).filtered("extra_demand_ids"):
@@ -176,6 +189,12 @@ class StockBuffer(models.Model):
                     % (ltaf, rec.name, prev, rec.dlt)
                 )
         return res
+
+    def action_archive(self):
+        self.env["ddmrp.adjustment.demand"].search(
+            [("buffer_origin_id", "in", self.ids)]
+        ).unlink()
+        return super().action_archive()
 
     def action_view_demand_to_components(self):
         demand_ids = (

--- a/ddmrp_adjustment/tests/test_adu_dlt_adjustment.py
+++ b/ddmrp_adjustment/tests/test_adu_dlt_adjustment.py
@@ -49,3 +49,4 @@ class TestAduAdjustment(TestDDMRPAdjustmentCommon):
         # Run actions
         self.assertTrue(self.buffer.action_view_demand_to_components())
         self.assertTrue(self.buffer.action_view_affecting_adu())
+        self.assertTrue(self.buffer.action_view_parent_affecting_adu())

--- a/ddmrp_adjustment/views/ddmrp_adjustment_demand_view.xml
+++ b/ddmrp_adjustment/views/ddmrp_adjustment_demand_view.xml
@@ -18,4 +18,10 @@
             </tree>
         </field>
     </record>
+    <record id="ddmrp_adjustment_demand_action" model="ir.actions.act_window">
+        <field name="name">Buffer Adjustments Demand</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">ddmrp.adjustment.demand</field>
+        <field name="view_mode">tree</field>
+    </record>
 </odoo>

--- a/ddmrp_adjustment/views/stock_buffer_view.xml
+++ b/ddmrp_adjustment/views/stock_buffer_view.xml
@@ -17,16 +17,23 @@
                 />
             </xpath>
             <button name="action_view_future_adu_indirect_demand" position="after">
+                <field name="daf_applied" invisible="1" />
+                <field name="parent_daf_applied" invisible="1" />
                 <button
-                    title="View DAF Affecting Actual ADU"
+                    title="View DAFs Affecting Actual ADU"
                     name="action_view_affecting_adu"
                     type="object"
                     attrs="{'invisible': [('daf_applied', '=', -1)]}"
                 >
-                    <div name="daf_applied" class="o_row">
-                        DAF: *
-                        <field name="daf_applied" readonly="1" />
-                    </div>
+                    <field name="daf_text" readonly="1" />
+                </button>
+                <button
+                    title="View Demand from parent DAFs Affecting Actual ADU"
+                    name="action_view_parent_affecting_adu"
+                    type="object"
+                    attrs="{'invisible': [('parent_daf_applied', '=', -1)]}"
+                >
+                    <field name="parent_daf_text" readonly="1" />
                 </button>
             </button>
         </field>

--- a/ddmrp_adjustment/views/stock_buffer_view.xml
+++ b/ddmrp_adjustment/views/stock_buffer_view.xml
@@ -8,12 +8,14 @@
         <field name="inherit_id" ref="ddmrp.stock_buffer_view_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
+                <field name="count_ddmrp_adjustment_demand" invisible="1" />
                 <button
                     string="DAF Demand Allocation"
                     name="action_view_demand_to_components"
                     class="oe_stat_button"
                     icon="fa-caret-square-o-down"
                     type="object"
+                    attrs="{'invisible': [('count_ddmrp_adjustment_demand', '=', 0)]}"
                 />
             </xpath>
             <button name="action_view_future_adu_indirect_demand" position="after">


### PR DESCRIPTION
Adds a button next to ADU to clearly see if the demand is being affected by a parent DAF.

@LoisRForgeFlow @ForgeFlow