### PR TITLE
[14.0][FIX] ddmrp_adjustment: do not overload original docstring of `_calc_adu`

### DIFF
--- a/ddmrp_adjustment/models/stock_buffer.py
+++ b/ddmrp_adjustment/models/stock_buffer.py
@@ -35,7 +35,7 @@ class StockBuffer(models.Model):
         return domain
 
     def _calc_adu(self):
-        """Apply DAFs if existing for the buffer."""
+        # Apply DAFs if existing for the buffer.
         res = super()._calc_adu()
         for rec in self:
             dafs_to_apply = self.env["ddmrp.adjustment"].search(


### PR DESCRIPTION
This has the side-effect of changing the description of the jobs spawned by the `ddmrp_cron_actions_as_job` module:
![image](https://github.com/OCA/ddmrp/assets/5315285/f6dc0b4c-679e-4730-8cfd-7707068bddb2)

This is misleading for users monitoring the job queue, and generated questions about this change.

cc @LoisRForgeFlow 