### PR TITLE
[15.0][FIX] ddmrp_adjustment: do not overload original docstring of _calc_adu

### DIFF
--- a/ddmrp_adjustment/models/stock_buffer.py
+++ b/ddmrp_adjustment/models/stock_buffer.py
@@ -37,7 +37,7 @@ class StockBuffer(models.Model):
         return domain
 
     def _calc_adu(self):
-        """Apply DAFs if existing for the buffer."""
+        # Apply DAFs if existing for the buffer.
         res = super()._calc_adu()
         for rec in self:
             dafs_to_apply = self.env["ddmrp.adjustment"].search(


### PR DESCRIPTION
This has the side-effect of changing the description of the jobs spawned by the 'ddmrp_cron_actions_as_job' module.

Fwport of #427 