### PR TITLE
[15.0][IMP] ddmrp: Add customized Stock Moves view

### DIFF
--- a/ddmrp/models/stock_move.py
+++ b/ddmrp/models/stock_move.py
@@ -1,7 +1,7 @@
 # Copyright 2019-20 ForgeFlow S.L. (http://www.forgeflow.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class StockMove(models.Model):
@@ -84,3 +84,69 @@ class StockMove(models.Model):
             buffer.cron_actions(only_nfp="out")
         for buffer in in_buffers.with_context(no_ddmrp_history=True):
             buffer.cron_actions(only_nfp="in")
+
+    def _get_all_linked_moves(self):
+        """Retrieve all linked moves both origin and destination recursively."""
+
+        def get_moves(move_set, attr):
+            new_moves = move_set.mapped(attr)
+            while new_moves:
+                move_set |= new_moves
+                new_moves = new_moves.mapped(attr)
+            return move_set
+
+        all_moves = (
+            self | get_moves(self, "move_orig_ids") | get_moves(self, "move_dest_ids")
+        )
+        return all_moves
+
+    def _get_source_field_candidates(self):
+        """Extend for more source field candidates."""
+        return [
+            "sale_line_id.order_id",
+            "purchase_line_id.order_id",
+            "production_id",
+            "raw_material_production_id",
+            "unbuild_id",
+            "repair_id",
+            "rma_line_id",
+            "picking_id",
+        ]
+
+    def _has_nested_field(self, field):
+        """Check if an object has a nested chain of fields."""
+        current_object = self
+        try:
+            for field in field.split("."):
+                current_object = getattr(current_object, field)
+            return True
+        except AttributeError:
+            return False
+
+    def _get_source_record(self):
+        """Find the first source record in the field candidates linked with the moves,
+        prioritizing the order of field candidates."""
+        moves = self._get_all_linked_moves()
+        field_candidates = self._get_source_field_candidates()
+        # Iterate over the prioritized list of candidate fields
+        for field in field_candidates:
+            if self._has_nested_field(field):
+                for move in moves:
+                    record = move.mapped(field)
+                    if record:
+                        return record
+        return False
+
+    def action_open_stock_move_source(self):
+        """Open the source record of the stock move, if it exists."""
+        self.ensure_one()
+        record = self._get_source_record()
+        if record:
+            return {
+                "name": getattr(record, "name", _("Stock Move Source")),
+                "view_mode": "form",
+                "res_model": record._name,
+                "type": "ir.actions.act_window",
+                "res_id": record.id,
+            }
+        return False

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -39,23 +39,18 @@
                 />
                 <field name="incoming_dlt_qty" string="Incoming Within DLT" />
                 <field
-                    name="incoming_total_qty"
-                    string="Total Incoming"
-                    optional="show"
-                />
-                <field
                     name="incoming_outside_dlt_qty"
                     string="Incoming Outside DLT"
                     optional="hide"
                 />
                 <field
-                    name="rfq_outside_dlt_qty"
-                    string="RFQ Qty Outside DLT"
-                    optional="hide"
+                    name="incoming_total_qty"
+                    string="Total Incoming"
+                    optional="show"
                 />
                 <button
-                    title="Open Non-completed Moves"
-                    name="open_moves"
+                    title="Total Incoming"
+                    name="action_view_supply_moves"
                     icon="fa-exchange"
                     type="object"
                 />
@@ -71,13 +66,22 @@
                 />
                 <button
                     title="Some incoming quantities are outside of the DLT Horizon and may require rescheduling. Press this button to display the involved supply orders"
-                    name="action_view_supply_outside_dlt_window"
+                    name="action_view_supply_moves_outside_dlt_window"
                     icon="fa-warning"
                     type="object"
-                    attrs="{'invisible':[('incoming_outside_dlt_qty', '=', 0), ('rfq_outside_dlt_qty', '=', 0)]}"
+                    attrs="{'invisible':[('incoming_outside_dlt_qty', '=', 0)]}"
+                />
+                <field name="rfq_outside_dlt_qty" invisible="1" />
+                <button
+                    title="Some RFQ quantities are outside of the DLT Horizon and may require rescheduling.
+                    Press this button to display the involved RFQs"
+                    name="action_view_supply_rfq_outside_dlt_window"
+                    icon="fa-warning"
+                    type="object"
+                    attrs="{'invisible':[('rfq_outside_dlt_qty', '=', 0)]}"
                 />
                 <button
-                    title="No stock available on source location for distributed buffer"
+                    title="No stock available in source location for distributed buffer"
                     name="action_dummy"
                     icon="fa-warning"
                     type="object"
@@ -397,8 +401,8 @@
                                 <div name="incoming_dlt_qty" class="o_row">
                                     <field name="incoming_dlt_qty" />
                                     <button
-                                        title="View Incoming (Within DLT)"
-                                        name="action_view_supply_inside_dlt_window"
+                                        title="View Incoming Moves (Within DLT)"
+                                        name="action_view_supply_moves_inside_dlt_window"
                                         icon="fa-search"
                                         type="object"
                                         attrs="{'invisible': [('incoming_dlt_qty', '=', 0)]}"
@@ -409,11 +413,24 @@
                                         attrs="{'invisible':[('incoming_outside_dlt_qty', '=', 0), ('rfq_outside_dlt_qty', '=', 0)]}"
                                     >
                                         <button
-                                            title="Some incoming quantities are outside of the DLT Horizon and may require rescheduling.
-                                            Press this button to display the involved supply orders"
-                                            name="action_view_supply_outside_dlt_window"
+                                            title="Some incoming qty is outside of the DLT Horizon and may require rescheduling.
+                                             Press this button to display the involved supply orders"
+                                            name="action_view_supply_moves_outside_dlt_window"
                                             icon="fa-warning"
                                             type="object"
+                                            attrs="{'invisible':[('incoming_outside_dlt_qty', '=', 0)]}"
+                                        />
+                                        <field
+                                            name="rfq_outside_dlt_qty"
+                                            invisible="1"
+                                        />
+                                        <button
+                                            title="Some incoming RFQs are outside of the DLT Horizon and may require rescheduling.
+                                             Press this button to display the involved supply orders"
+                                            name="action_view_supply_rfq_outside_dlt_window"
+                                            icon="fa-warning"
+                                            type="object"
+                                            attrs="{'invisible':[('rfq_outside_dlt_qty', '=', 0)]}"
                                         />
                                         (Outside DLT:
                                         <field
@@ -436,7 +453,7 @@
                                     />
                                     <button
                                         title="View Qualified Demand from Pickings"
-                                        name="action_view_qualified_demand_pickings"
+                                        name="action_view_qualified_demand_moves"
                                         icon="fa-search"
                                         type="object"
                                         attrs="{'invisible': ['|', ('qualified_demand', '=', 0), ('qualified_demand_stock_move_ids', '=', [])]}"

--- a/ddmrp/views/stock_move_views.xml
+++ b/ddmrp/views/stock_move_views.xml
@@ -2,15 +2,18 @@
 <!-- Copyright 2018-20 ForgeFlow S.L. (http://www.forgeflow.com)
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
 <odoo>
-    <!--Fixes to show date on stock move report-->
-    <!--If someday Odoo corrects this, we could remove this views-->
     <record id="view_move_tree" model="ir.ui.view">
         <field name="name">stock.move.tree</field>
         <field name="model">stock.move</field>
         <field name="inherit_id" ref="stock.view_move_tree" />
         <field name="arch" type="xml">
-            <field name="date" position="after">
-                <field name="date" />
+            <field name="state" position="after">
+                <button
+                    title="Go to Source"
+                    name="action_open_stock_move_source"
+                    icon="fa-arrow-right"
+                    type="object"
+                />
             </field>
         </field>
     </record>


### PR DESCRIPTION
When checking incoming quantities or qualified demand moves, we will use a customized view that allows to redirect to the source document of that move.

A stock move can be chained with many other moves and can have two sources, like a dropship. Then, to calculate the source of that stock move, a list of fields ordered by priority is followed, in which if any record is found in any of them, it is returned as a source. For example, if we have a stock move that belongs to a dropship with related sale and purchase, it will always return the sale as source because its the first field in the list. The sources field method is extensible to add any others that are needed.

Source: https://github.com/OCA/ddmrp/pull/442