### PR TITLE
[16.0][IMP] ddmrp: Make fields invisible or readonly if user not in group

### DIFF
--- a/ddmrp/wizards/make_procurement_buffer.py
+++ b/ddmrp/wizards/make_procurement_buffer.py
@@ -29,7 +29,6 @@ class MakeProcurementBuffer(models.TransientModel):
         return {
             "recommended_qty": buffer.procure_recommended_qty,
             "qty": qty,
-            "qty_without_security": qty,
             "uom_id": buffer.procure_uom_id.id or buffer.product_uom.id,
             "date_planned": buffer._get_date_planned(),
             "buffer_id": buffer.id,
@@ -37,17 +36,6 @@ class MakeProcurementBuffer(models.TransientModel):
             "warehouse_id": buffer.warehouse_id.id,
             "location_id": buffer.location_id.id,
         }
-
-    @api.model
-    def fields_view_get(
-        self, view_id=None, view_type="form", toolbar=False, submenu=False
-    ):
-        if not self.user_has_groups("ddmrp.group_change_buffer_procure_qty"):
-            # Redirect to readonly qty form view
-            view_id = self.env.ref("ddmrp.view_make_procure_without_security").id
-        return super().fields_view_get(
-            view_id=view_id, view_type=view_type, toolbar=toolbar, submenu=submenu
-        )
 
     @api.model
     def default_get(self, fields):
@@ -172,7 +160,6 @@ class MakeProcurementBufferItem(models.TransientModel):
     )
     recommended_qty = fields.Float(readonly=True)
     qty = fields.Float()
-    qty_without_security = fields.Float(string="Quantity")
     uom_id = fields.Many2one(
         string="Unit of Measure",
         comodel_name="uom.uom",

--- a/ddmrp/wizards/make_procurement_buffer_view.xml
+++ b/ddmrp/wizards/make_procurement_buffer_view.xml
@@ -47,8 +47,15 @@
                         />
                         <field name="product_id" />
                         <field name="recommended_qty" />
-                        <field name="qty" />
-                        <field name="qty_without_security" invisible="1" />
+                        <field
+                            name="qty"
+                            readonly="1"
+                            groups="!ddmrp.group_change_buffer_procure_qty"
+                        />
+                        <field
+                            name="qty"
+                            groups="ddmrp.group_change_buffer_procure_qty"
+                        />
                         <field name="uom_id" groups="uom.group_uom" />
                         <field name="date_planned" />
                     </tree>
@@ -63,22 +70,6 @@
                     <button string="Cancel" class="btn-default" special="cancel" />
                 </footer>
             </form>
-        </field>
-    </record>
-    <!--  Make Procurement without security access right -->
-    <record id="view_make_procure_without_security" model="ir.ui.view">
-        <field name="name">Request Procurement</field>
-        <field name="model">make.procurement.buffer</field>
-        <field name="mode">primary</field>
-        <field name="inherit_id" ref="ddmrp.view_make_procurement_buffer_wizard" />
-        <field name="arch" type="xml">
-            <field name="qty" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field>
-            <field name="qty_without_security" position="attributes">
-                <attribute name="readonly">1</attribute>
-                <attribute name="invisible">0</attribute>
-            </field>
         </field>
     </record>
     <record id="act_make_procurement_from_buffer" model="ir.actions.act_window">

--- a/ddmrp/wizards/make_procurement_buffer_view.xml
+++ b/ddmrp/wizards/make_procurement_buffer_view.xml
@@ -29,6 +29,16 @@
                         <field name="buffer_id" invisible="True" />
                         <field
                             name="warehouse_id"
+                            invisible="1"
+                            groups="!stock.group_stock_multi_locations"
+                        />
+                        <field
+                            name="location_id"
+                            invisible="1"
+                            groups="!stock.group_stock_multi_locations"
+                        />
+                        <field
+                            name="warehouse_id"
                             groups="stock.group_stock_multi_locations"
                         />
                         <field


### PR DESCRIPTION
If the user is not in 'Technical / Manage Multiple Stock Locations' group, he won't be able to see the warehouse and location in the procurement wizard.

If the user is not in 'DDMRP / Change quantity in manual procurements from Stock Buffers' group, he won't be able to edit the quantity in the procurement wizard.