### PR TITLE
[16.0][FIX] ddmrp: when procuring without permissions to change qty an error raises

### DIFF
--- a/ddmrp/wizards/make_procurement_buffer_view.xml
+++ b/ddmrp/wizards/make_procurement_buffer_view.xml
@@ -50,6 +50,7 @@
                         <field
                             name="qty"
                             readonly="1"
+                            force_save="1"
                             groups="!ddmrp.group_change_buffer_procure_qty"
                         />
                         <field


### PR DESCRIPTION
qty is not saved and "Quantity must be positive." error appears. Using `force_save` fixes the problem.