### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/ddmrp_purchase_hide_onhand_status/__manifest__.py
+++ b/ddmrp_purchase_hide_onhand_status/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "DDMRP Purchase Hide On-Hand Status",
     "version": "14.0.1.0.0",
     "summary": "Replace purchase onhand status with smart button.",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "development_status": "Beta",
     "maintainers": ["TDu"],
     "website": "https://github.com/OCA/ddmrp",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.