### PR TITLE
[14.0][IMP] ddmrp_warning: add datetime, time and dateutil in safe_eval expression

### DIFF
--- a/ddmrp_warning/models/ddmrp_warning_definition.py
+++ b/ddmrp_warning/models/ddmrp_warning_definition.py
@@ -1,7 +1,7 @@
 # Copyright 2021 ForgeFlow S.L. (https://www.forgeflow.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
-from odoo import _, fields, models
+from odoo import _, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools.safe_eval import safe_eval
@@ -50,7 +50,15 @@ class DdmrpWarningDefinition(models.Model):
     def evaluate_definition(self, buffer):
         self.ensure_one()
         try:
-            res = safe_eval(self.python_code, globals_dict={"buffer": buffer})
+            res = safe_eval(
+                self.python_code,
+                globals_dict={
+                    "buffer": buffer,
+                    "time": tools.safe_eval.time,
+                    "datetime": tools.safe_eval.datetime,
+                    "dateutil": tools.safe_eval.dateutil,
+                },
+            )
         except Exception as error:
             raise UserError(_("Error evaluating %s.\n %s") % (self._name, error))
         return res


### PR DESCRIPTION
Back Port of https://github.com/OCA/ddmrp/pull/465

@ForgeFlow 