### PR TITLE
[17.0][REF] ddmrp: substitute created_purchase_line_id.

### DIFF
--- a/ddmrp/models/purchase_order.py
+++ b/ddmrp/models/purchase_order.py
@@ -81,7 +81,7 @@ class PurchaseOrderLine(models.Model):
         move_model = self.env["stock.move"]
         for rec in self.filtered(lambda r: not r.buffer_ids):
             mto_move = move_model.search(
-                [("created_purchase_line_id", "=", rec.id)], limit=1
+                [("created_purchase_line_ids", "in", rec.id)], limit=1
             )
             if mto_move:
                 # MTO lines are not accounted in MTS stock buffers.

--- a/ddmrp/models/stock_move.py
+++ b/ddmrp/models/stock_move.py
@@ -11,8 +11,6 @@ class StockMove(models.Model):
         comodel_name="stock.buffer",
         string="Linked Stock Buffers",
     )
-    # Add an index as '_find_buffer_link' method is using it as search criteria
-    created_purchase_line_id = fields.Many2one(index=True)
 
     def _prepare_procurement_values(self):
         res = super()._prepare_procurement_values()


### PR DESCRIPTION
This field was removed in 17.0, now is a m2m 'created_purchase_line_ids'.