### PR TITLE
[16.0][FIX] ddmrp: print BoM Overview correctly show is buffered.

### DIFF
--- a/ddmrp/report/mrp_report_bom_structure.py
+++ b/ddmrp/report/mrp_report_bom_structure.py
@@ -86,10 +86,13 @@ class BomStructureReport(models.AbstractModel):
             data, level, unfolded_ids, unfolded, parent_unfolded
         )
         for component in data.get("components", []):
-            if not component["bom_id"]:
-                continue
             bom_line = next(
-                filter(lambda l: l.get("bom_id", None) == component["bom_id"], lines)
+                filter(
+                    lambda line: line.get("bom_id", False) == component["bom_id"]
+                    and line.get("name", False) == component["name"]
+                    and line.get("level", False) == component["level"],
+                    lines,
+                )
             )
             if bom_line:
                 bom_line["is_buffered"] = component["is_buffered"]

--- a/ddmrp/report/mrp_report_bom_structure.xml
+++ b/ddmrp/report/mrp_report_bom_structure.xml
@@ -6,7 +6,7 @@
 
         <xpath expr="//td[@name='td_mrp_bom']" position="before">
             <td t-if="data['show_buffered']">
-                <span>
+                <span t-if="data['is_buffered']">
                     <img
                         src='/ddmrp/static/img/is_buffered.png'
                         style="width:30px;height:30px;padding:5px"


### PR DESCRIPTION
Backport of #475 

@ForgeFlow