### PR TITLE
[17.0][FIX] ddmrp: readd procure_location argument lost in migration

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -2077,14 +2077,9 @@ class StockBuffer(models.Model):
     def _values_source_location_from_route(self):
         return {"warehouse_id": self.warehouse_id}
 
-    def _source_location_from_route(self, route=None):
-        """Return the replenishment source location for distributed buffers
-        If no route is passed, it follows the source location of the rules of
-        all the routes it finds until it can no longer find a path.
-        If a route is passed, it stops at the final source location of the
-        rules of this route only.
-        """
-        current_location = self.location_id
+    def _source_location_from_route(self, procure_location=None):
+        """Return the replenishment source location for distributed buffers"""
+        current_location = procure_location or self.location_id
         rule_values = self._values_source_location_from_route()
         while current_location:
             rule = self.env["procurement.group"]._get_rule(


### PR DESCRIPTION
route argument is removed because is not used anywhere.

This was lost in migration to v 16.0.

Original commit details:

[FIX] ddmrp: Check sublocations in Stock Buffers

Sometimes, we want to define a Stock Buffer with entire warehouse visibility but we have Stock Demand Estimates or BoMs defined in sublocations. This commit allows to see objects defined in sublocations.

Author:    BernatPForgeFlow <bernat.puig@forgeflow.com>
Date:      Mon Jun 5 11:21:34 2023 +0200

Fwport of https://github.com/OCA/ddmrp/pull/478 and Missed fwport from https://github.com/OCA/ddmrp/pull/284.