### PR TITLE
[17.0][FIX] ddmrp_warning: default severity 2_mid

### DIFF
--- a/ddmrp_warning/models/ddmrp_warning_definition.py
+++ b/ddmrp_warning/models/ddmrp_warning_definition.py
@@ -23,7 +23,7 @@ class DdmrpWarningDefinition(models.Model):
     )
     severity = fields.Selection(
         selection=[("1_low", "Low"), ("2_mid", "Medium"), ("3_high", "High")],
-        default="mid",
+        default="2_mid",
     )
     active = fields.Boolean(default=True)
     warning_domain = fields.Char(


### PR DESCRIPTION
There was an error that didn't let you create a warning definition.

![image](https://github.com/user-attachments/assets/ebc31275-ad2b-4a87-be8b-497c3310915a)
