### PR TITLE
[16.0][IMP] ddmrp_sale: evaluate sale line route to consider qualified demand

### DIFF
--- a/ddmrp_sale/models/stock_buffer.py
+++ b/ddmrp_sale/models/stock_buffer.py
@@ -15,12 +15,13 @@ class StockBuffer(models.Model):
         comodel_name="sale.order.line",
     )
 
-    def _get_sale_source_location(self):
+    def _get_sale_source_location(self, route_id=False):
         self.ensure_one()
         proc_loc = self.env.ref("stock.stock_location_customers")
         values = {
             "warehouse_id": self.warehouse_id,
             "company_id": self.company_id,
+            "route_ids": route_id,
         }
         rule = self.env["procurement.group"]._get_rule(
             self.product_id, proc_loc, values
@@ -52,6 +53,15 @@ class StockBuffer(models.Model):
     def _search_sales_qualified_demand(self):
         domain = self._search_sales_qualified_demand_domain()
         so_lines = self.env["sale.order.line"].search(domain)
+        locations = self.env["stock.location"].search(
+            [("id", "child_of", [self.location_id.id])]
+        )
+        for so_line in so_lines:
+            if not so_line.route_id:
+                continue
+            source_location = self._get_sale_source_location(so_line.route_id)
+            if not source_location or source_location not in locations:
+                so_lines -= so_line
         return so_lines
 
     def _get_so_lines_by_days(self, so_lines):

--- a/ddmrp_sale/tests/test_ddmrp_sale.py
+++ b/ddmrp_sale/tests/test_ddmrp_sale.py
@@ -29,6 +29,37 @@ class TestDDMRPSale(TestDdmrpCommon):
             }
         )
 
+        # Create dropship route
+        cls.route = cls.env["stock.route"].create(
+            {
+                "name": "Dropship",
+                "sale_selectable": True,
+            }
+        )
+        supplier_location = cls.env.ref("stock.stock_location_suppliers")
+        customer_location = cls.env.ref("stock.stock_location_customers")
+        picking_type = cls.env["stock.picking.type"].create(
+            {
+                "name": "Dropship",
+                "warehouse_id": False,
+                "code": "incoming",
+                "default_location_src_id": supplier_location.id,
+                "default_location_dest_id": customer_location.id,
+                "sequence_code": "DS",
+            }
+        )
+        cls.env["stock.rule"].create(
+            {
+                "name": "Dropship",
+                "route_id": cls.route.id,
+                "location_src_id": supplier_location.id,
+                "location_dest_id": customer_location.id,
+                "action": "buy",
+                "picking_type_id": picking_type.id,
+                "procure_method": "make_to_stock",
+            }
+        )
+
     @classmethod
     def _refresh_involved_buffers(cls):
         cls.buffer_a.invalidate_recordset()
@@ -113,3 +144,38 @@ class TestDDMRPSale(TestDdmrpCommon):
         self._refresh_involved_buffers()
         diff = self.buffer_a.qualified_demand - self.buffer_internal.qualified_demand
         self.assertEqual(diff, 24)
+
+    def test_04_sales_quotation_not_included_as_demand(self):
+        self._refresh_involved_buffers()
+        self.assertEqual(
+            self.buffer_a.qualified_demand, self.buffer_internal.qualified_demand
+        )
+        so_date = dt.today() + td(days=2)
+        so = self.so_model.create(
+            {
+                "partner_id": self.customer.id,
+                "partner_invoice_id": self.customer.id,
+                "partner_shipping_id": self.customer.id,
+                "commitment_date": so_date,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.productA.id,
+                            "name": "cool product",
+                            "price_unit": 100.0,
+                            "product_uom_qty": 17,  # it is a spike.
+                            "commitment_date": so_date,
+                            "route_id": self.route.id,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(so.state, "draft")
+        self._refresh_involved_buffers()
+        # Qualified demand ignored as the line route does not affect the buffer
+        # location
+        self.assertEqual(self.buffer_a.qualified_demand, 0)
+        self.assertEqual(self.buffer_internal.qualified_demand, 0)


### PR DESCRIPTION
When looking at sale lines for the sale qualified demand we should take into account the route that is being forced (if any) in the sale line.