### PR TITLE
[16.0][IMP] ddmrp_warning: various improvements

### DIFF
--- a/ddmrp_warning/data/ddmrp_warning_definition_data.xml
+++ b/ddmrp_warning/data/ddmrp_warning_definition_data.xml
@@ -15,7 +15,7 @@
         <field name="name">Quantity multiple bigger than MOQ</field>
         <field
             name="python_code"
-        >buffer.minimum_order_quantity &lt; buffer.qty_multiple</field>
+        >buffer.minimum_order_quantity &gt; 0 and buffer.minimum_order_quantity &lt; buffer.qty_multiple</field>
         <field name="severity">2_mid</field>
     </record>
     <record

--- a/ddmrp_warning/models/ddmrp_warning_definition.py
+++ b/ddmrp_warning/models/ddmrp_warning_definition.py
@@ -32,6 +32,11 @@ class DdmrpWarningDefinition(models.Model):
         help="Domain based on Stock Buffer, to define if the "
         "warning is applicable or not.",
     )
+    ddmrp_warning_item_ids = fields.One2many(
+        comodel_name="ddmrp.warning.item",
+        inverse_name="warning_definition_id",
+        readonly=True,
+    )
 
     def _eval_warning_domain(self, buffer, domain):
         buffer_domain = [("id", "=", buffer.id)]
@@ -64,4 +69,11 @@ class DdmrpWarningDefinition(models.Model):
                 _("Error evaluating %(name)s.\n %(error)s")
                 % ({"name": self._name, "error": error})
             ) from error
+        return res
+
+    def write(self, vals):
+        # Unlink warning items when definition is archived
+        res = super().write(vals)
+        if "active" in vals and not vals.get("active"):
+            self.ddmrp_warning_item_ids.unlink()
         return res

--- a/ddmrp_warning/models/ddmrp_warning_item.py
+++ b/ddmrp_warning/models/ddmrp_warning_item.py
@@ -11,6 +11,7 @@ class DdmrpWarningItem(models.Model):
 
     warning_definition_id = fields.Many2one(
         comodel_name="ddmrp.warning.definition",
+        ondelete="cascade",
     )
     buffer_id = fields.Many2one(comodel_name="stock.buffer", ondelete="cascade")
     name = fields.Char(

--- a/ddmrp_warning/models/stock_buffer.py
+++ b/ddmrp_warning/models/stock_buffer.py
@@ -70,3 +70,10 @@ class Buffer(models.Model):
             if auto_commit:
                 self._cr.commit()  # pylint: disable=E8102
         return True
+
+    def write(self, vals):
+        # Unlink warning items when buffer is archived
+        res = super().write(vals)
+        if "active" in vals and not vals.get("active"):
+            self.ddmrp_warning_item_ids.unlink()
+        return res

--- a/ddmrp_warning/tests/test_ddmrp_warning.py
+++ b/ddmrp_warning/tests/test_ddmrp_warning.py
@@ -45,3 +45,17 @@ class TestDDMRPWarning(TestDdmrpCommon):
         self._refresh_involved_buffers()
         new_count = len(self.buffer_warnings.ddmrp_warning_item_ids)
         self.assertEqual(prev_count - new_count, 1)
+
+    def test_02_buffer_archive(self):
+        self._refresh_involved_buffers()
+        self.assertTrue(self.buffer_warnings.ddmrp_warning_item_ids)
+        self.buffer_warnings.active = False
+        self.assertFalse(self.buffer_warnings.ddmrp_warning_item_ids)
+
+    def test_03_definition_archive(self):
+        self._refresh_involved_buffers()
+        self.assertTrue(self.spike_warning.ddmrp_warning_item_ids)
+        self.assertTrue(self.buffer_warnings.ddmrp_warning_item_ids)
+        self.spike_warning.active = False
+        self.assertFalse(self.spike_warning.ddmrp_warning_item_ids)
+        self.assertFalse(self.buffer_warnings.ddmrp_warning_item_ids)


### PR DESCRIPTION
- Prevent Quantity multiple bigger than MOQ warning when MOQ is 0
- Unlink warning items when warning definition is deleted
- Unlink warning items when buffer is archived