### PR TITLE
Revert [FIX] ddmrp: adapt tests to recent upstream changes.

### DIFF
--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -1141,15 +1141,7 @@ class TestDdmrp(TestDdmrpCommon):
                 ],
             }
         )
-        # because of the issue discussed here https://github.com/odoo/odoo/pull/188846
-        # we need to apply routes explicitly in the proper order (by sequence)
-        self.product_purchased.route_ids = [
-            (
-                6,
-                0,
-                (route + self.env.ref("purchase_stock.route_warehouse0_buy")).ids,
-            )
-        ]
+        self.product_purchased.route_ids |= route
         buffer_distributed = self.bufferModel.create(
             {
                 "buffer_profile_id": self.buffer_profile_distr.id,


### PR DESCRIPTION
After https://github.com/odoo/odoo/commit/aaed0ae359e0367aaf4a3f0837f478b0115d2bbf
we can revert https://github.com/OCA/ddmrp/commit/ebd563397b5d4ed257001b8805a77c02ccf7f817