### PR TITLE
[17.0][IMP] ddmrp_exclude_moves_adu_calc: run calc adu after toggle exlude_from_adu field

### DIFF
--- a/ddmrp_exclude_moves_adu_calc/models/stock_move.py
+++ b/ddmrp_exclude_moves_adu_calc/models/stock_move.py
@@ -23,3 +23,10 @@ class StockMove(models.Model):
             )
         for rec in self:
             rec.exclude_from_adu = not rec.exclude_from_adu
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "exclude_from_adu" in vals:
+            out_buffers, in_buffers = self._find_buffers_to_update_nfp()
+            (out_buffers + in_buffers)._calc_adu()
+        return res

--- a/ddmrp_exclude_moves_adu_calc/tests/test_ddmrp.py
+++ b/ddmrp_exclude_moves_adu_calc/tests/test_ddmrp.py
@@ -209,6 +209,5 @@ class TestDdmrp(common.TransactionCase):
         # Exclude specific moves:
         for move in pick_excluded.move_ids:
             move.exclude_from_adu = True
-        self.bufferModel.cron_ddmrp_adu()
         to_assert_value = 60 / 120
         self.assertEqual(buffer_a.adu, to_assert_value)


### PR DESCRIPTION
To keep the buffer synchronized, the ADU of the affected buffers is forced to recalculate when the exclude_from_adu value of a stock_move is changed.

@ForgeFlow 