### PR TITLE
[13.0][IMP]ddmrp_chatter: track `procure_recommended_qty` values

### DIFF
--- a/ddmrp_chatter/models/stock_buffer.py
+++ b/ddmrp_chatter/models/stock_buffer.py
@@ -22,3 +22,4 @@ class Buffer(models.Model):
     qty_multiple = fields.Float(tracking=True)
     auto_procure = fields.Boolean(tracking=True)
     auto_procure_option = fields.Selection(tracking=True)
+    procure_recommended_qty = fields.Float(tracking=True)


### PR DESCRIPTION
On top of the rest of the Buffer fields to be tracked, as the Procure Recommendation quantity, as it might be interesting to have a traceability of whenever it gets updated

cc @ForgeFlow