### PR TITLE
[18.0][FIX] ddmrp: wrong product domain for v18

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -93,7 +93,7 @@ class StockBuffer(models.Model):
     product_id = fields.Many2one(
         comodel_name="product.product",
         string="Product",
-        domain=[("type", "=", "product")],
+        domain=[("is_storable", "=", True)],
         ondelete="cascade",
         required=True,
     )


### PR DESCRIPTION
small leftoever from migration.