### PR TITLE
[18.0][IMP] ddmrp: consider that done quantity and demand can be different in stock.move

### DIFF
--- a/ddmrp/README.rst
+++ b/ddmrp/README.rst
@@ -72,12 +72,12 @@ a wide variety of leading companies across the world.
 
 Some of the benefits reported by the DDMRP method include:
 
-- High fill rate performance
-- Lead time reductions
-- Inventory reductions, while improving customer service
-- Eliminate costs related to expedite
-- Planners see priorities instead of constantly fighting the conflicting
-  messages of MRP
+-  High fill rate performance
+-  Lead time reductions
+-  Inventory reductions, while improving customer service
+-  Eliminate costs related to expedite
+-  Planners see priorities instead of constantly fighting the
+   conflicting messages of MRP
 
 It is highly recommended to read the book 'Demand Driven Material
 Requirements Planning (DDMRP)' by Carol Ptak and Chad Smith.
@@ -105,11 +105,11 @@ Configuration
 Scheduled actions
 -----------------
 
-- Go to *Settings > Technical*.
-- 'DDMRP Buffer ADU calculation'. Computes the Average Daily Usage for
-  all Buffers.
-- 'Reordering Rule DDMRP calculation'. Computes the Qualified Demand,
-  Net Flow Position, Planning and Execution priorities for all Buffers.
+-  Go to *Settings > Technical*.
+-  'DDMRP Buffer ADU calculation'. Computes the Average Daily Usage for
+   all Buffers.
+-  'Reordering Rule DDMRP calculation'. Computes the Qualified Demand,
+   Net Flow Position, Planning and Execution priorities for all Buffers.
 
 Decoupled Lead Time computation
 -------------------------------
@@ -119,19 +119,19 @@ The DLT is automatically computed by the system.
 For manufactured products' buffers just remember to provide and set
 properly the following information:
 
-- The *Manufacturing Lead Time* for the manufactured product. It can be
-  found at the product form view under the tab *Sales*.
-- The *Delivery Lead Time* for the preferred vendor of a product. This
-  is important for the products which are purchased and are components
-  in any Bill of Materials.
+-  The *Manufacturing Lead Time* for the manufactured product. It can be
+   found at the product form view under the tab *Sales*.
+-  The *Delivery Lead Time* for the preferred vendor of a product. This
+   is important for the products which are purchased and are components
+   in any Bill of Materials.
 
 For purchased/distributed products' buffers the logic is simpler.
 
-- In the first place the system will look if there are Vendors for the
-  product, if so it will use the *Delivery Lead Time* of the preferred
-  one.
-- In case of absence of vendors, the *Lead Time* at the bottom of the
-  Buffer form view will be used.
+-  In the first place the system will look if there are Vendors for the
+   product, if so it will use the *Delivery Lead Time* of the preferred
+   one.
+-  In case of absence of vendors, the *Lead Time* at the bottom of the
+   Buffer form view will be used.
 
 Usage
 =====
@@ -140,13 +140,13 @@ To easily identify were are you maintaining buffers in your Bill of
 Materials, you will need to first provide location information on the
 Bills of Materials.
 
-- Go to *Manufacturing / Products / Bill of Materials* and update the
-  'Location' in all the Bill of Materials and associated lines,
-  indicating where will the parts be placed/used during the
-  manufacturing process.
-- Print the report 'BOM Structure' to display where in your BOM are you
-  maintaining buffers, and to identify the Lead Time (LT) of each
-  product, and Decouple Lead Time (DLT).
+-  Go to *Manufacturing / Products / Bill of Materials* and update the
+   'Location' in all the Bill of Materials and associated lines,
+   indicating where will the parts be placed/used during the
+   manufacturing process.
+-  Print the report 'BOM Structure' to display where in your BOM are you
+   maintaining buffers, and to identify the Lead Time (LT) of each
+   product, and Decouple Lead Time (DLT).
 
 Buffers
 -------
@@ -162,21 +162,21 @@ Buffer profiles make maintenance of buffers easier by grouping them in
 profiles. Changes applied to the profiles will be applicable in the
 associated buffer calculations.
 
-- Go to *Inventory / Configuration / Buffer Profiles*.
+-  Go to *Inventory / Configuration / Buffer Profiles*.
 
 The Buffer Profile Lead Time Factor influences the size of the Buffer
 Green zone. Items with longer lead times will usually have smaller green
 zones, which will translate in more frequent supply order generation.
 
-- Go to *Inventory / Configuration / Buffer Profile Lead Time Factor* to
-  chan
+-  Go to *Inventory / Configuration / Buffer Profile Lead Time Factor*
+   to chan
 
 The Buffer Profile Variability Factor influences the size of the Buffer
 Red Safety zone. Items with longer lead times will usually have smaller
 green zones, which will translate in more frequent supply order
 generation.
 
-- Go to *Inventory / Configuration / Buffer Profile Lead Time Factor*.
+-  Go to *Inventory / Configuration / Buffer Profile Lead Time Factor*.
 
 Usual factors should range from 0.2 (long lead time) to 0.8 (short lead
 time).
@@ -184,11 +184,12 @@ time).
 Product attributes
 ------------------
 
-- For manufactured products, go to *Manufacturing / Products* and update
-  the 'Manufacturing Lead Time' field, available in the tab *Inventory*.
-- For purchased products, go to go to *Purchasing / Products* and update
-  the *Delivery Lead Time* for each vendor, available in tab *Purchase*
-  and section *Vendors*.
+-  For manufactured products, go to *Manufacturing / Products* and
+   update the 'Manufacturing Lead Time' field, available in the tab
+   *Inventory*.
+-  For purchased products, go to go to *Purchasing / Products* and
+   update the *Delivery Lead Time* for each vendor, available in tab
+   *Purchase* and section *Vendors*.
 
 ADU Calculation Methods
 -----------------------
@@ -235,43 +236,43 @@ Changelog
 
 **Features**
 
-- 
+-  
 
-  - New setting *Update NFP on Stock Buffers on relevant events*.
-  - New dedicated settings block.
-    (`#50 <https://github.com/OCA/ddmrp/issues/50>`__)
+   -  New setting *Update NFP on Stock Buffers on relevant events*.
+   -  New dedicated settings block.
+      (`#50 <https://github.com/OCA/ddmrp/issues/50>`__)
 
 13.0.1.0.0 (2020-06-11)
 -----------------------
 
-- [MIG/REF] Migration of module to v13 and refactor (added new dedicated
-  model for stock buffer).
+-  [MIG/REF] Migration of module to v13 and refactor (added new
+   dedicated model for stock buffer).
 
 11.0.1.3.0 (2019-02-21)
 -----------------------
 
-- [ADD] New chart that depict information about the supply and demand (
-  displaying also de order spike threshold and horizon) for a buffer.
-  (`#40 <https://github.com/OCA/ddmrp/pull/40>`__)
+-  [ADD] New chart that depict information about the supply and demand (
+   displaying also de order spike threshold and horizon) for a buffer.
+   (`#40 <https://github.com/OCA/ddmrp/pull/40>`__)
 
 11.0.1.2.0 (2019-01-29)
 -----------------------
 
-- [IMP] Performance improvement of execution priority calculation and
-  ADU. (`#36 <https://github.com/OCA/ddmrp/pull/36>`__)
-- [IMP] Use the minimum quantity to adjust the procure recommendation.
-  (`#37 <https://github.com/OCA/ddmrp/pull/37>`__)
+-  [IMP] Performance improvement of execution priority calculation and
+   ADU. (`#36 <https://github.com/OCA/ddmrp/pull/36>`__)
+-  [IMP] Use the minimum quantity to adjust the procure recommendation.
+   (`#37 <https://github.com/OCA/ddmrp/pull/37>`__)
 
 11.0.1.1.0 (2018-08-31)
 -----------------------
 
-- [IMP] Implemented Blended ADU calculation method.
-  (`#23 <https://github.com/OCA/ddmrp/pull/23>`__)
+-  [IMP] Implemented Blended ADU calculation method.
+   (`#23 <https://github.com/OCA/ddmrp/pull/23>`__)
 
 11.0.1.0.0 (2018-07-16)
 -----------------------
 
-- Start of the history
+-  Start of the history
 
 Bug Tracker
 ===========
@@ -294,11 +295,11 @@ Authors
 Contributors
 ------------
 
-- Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
-- Lois Rilo Antelo <lois.rilo@forgeflow.com>
-- Guewen Baconnier <guewen.baconnier@camptocamp.com>
-- Adria Gil Sorribes <adria.gil@forgeflow.com>
-- Christopher Ormaza <chris.ormaza@forgeflow.com>
+-  Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
+-  Lois Rilo Antelo <lois.rilo@forgeflow.com>
+-  Guewen Baconnier <guewen.baconnier@camptocamp.com>
+-  Adria Gil Sorribes <adria.gil@forgeflow.com>
+-  Christopher Ormaza <chris.ormaza@forgeflow.com>
 
 Other credits
 -------------
@@ -306,7 +307,7 @@ Other credits
 The initial development of this module has been financially supported
 by:
 
-- Aleph Objects, Inc.
+-  Aleph Objects, Inc.
 
 Maintainers
 -----------

--- a/ddmrp/__manifest__.py
+++ b/ddmrp/__manifest__.py
@@ -20,6 +20,7 @@
         "base_cron_exclusion",
         "stock_warehouse_calendar",
         "stock_location_is_sublocation",
+        "stock_move_quantity_product_uom",
     ],
     "data": [
         "data/product_adu_calculation_method_data.xml",

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1451,9 +1451,9 @@ class StockBuffer(models.Model):
         elif self.adu_calculation_method.source_past == "actual":
             domain = self._past_moves_domain(date_from, date_to, locations)
             for group in self.env["stock.move"].read_group(
-                domain, ["product_id", "product_qty"], ["product_id"]
+                domain, ["product_id", "quantity_product_uom"], ["product_id"]
             ):
-                qty += group["product_qty"]
+                qty += group["quantity_product_uom"]
         return qty / horizon
 
     def _get_horizon_adu_future_demand(self):

--- a/ddmrp/static/description/index.html
+++ b/ddmrp/static/description/index.html
@@ -412,8 +412,8 @@ a wide variety of leading companies across the world.</p>
 <li>Lead time reductions</li>
 <li>Inventory reductions, while improving customer service</li>
 <li>Eliminate costs related to expedite</li>
-<li>Planners see priorities instead of constantly fighting the conflicting
-messages of MRP</li>
+<li>Planners see priorities instead of constantly fighting the
+conflicting messages of MRP</li>
 </ul>
 <p>It is highly recommended to read the book ‘Demand Driven Material
 Requirements Planning (DDMRP)’ by Carol Ptak and Chad Smith.</p>
@@ -530,8 +530,8 @@ associated buffer calculations.</p>
 Green zone. Items with longer lead times will usually have smaller green
 zones, which will translate in more frequent supply order generation.</p>
 <ul class="simple">
-<li>Go to <em>Inventory / Configuration / Buffer Profile Lead Time Factor</em> to
-chan</li>
+<li>Go to <em>Inventory / Configuration / Buffer Profile Lead Time Factor</em>
+to chan</li>
 </ul>
 <p>The Buffer Profile Variability Factor influences the size of the Buffer
 Red Safety zone. Items with longer lead times will usually have smaller
@@ -546,11 +546,12 @@ time).</p>
 <div class="section" id="product-attributes">
 <h2><a class="toc-backref" href="#toc-entry-8">Product attributes</a></h2>
 <ul class="simple">
-<li>For manufactured products, go to <em>Manufacturing / Products</em> and update
-the ‘Manufacturing Lead Time’ field, available in the tab <em>Inventory</em>.</li>
-<li>For purchased products, go to go to <em>Purchasing / Products</em> and update
-the <em>Delivery Lead Time</em> for each vendor, available in tab <em>Purchase</em>
-and section <em>Vendors</em>.</li>
+<li>For manufactured products, go to <em>Manufacturing / Products</em> and
+update the ‘Manufacturing Lead Time’ field, available in the tab
+<em>Inventory</em>.</li>
+<li>For purchased products, go to go to <em>Purchasing / Products</em> and
+update the <em>Delivery Lead Time</em> for each vendor, available in tab
+<em>Purchase</em> and section <em>Vendors</em>.</li>
 </ul>
 </div>
 <div class="section" id="adu-calculation-methods">
@@ -605,8 +606,8 @@ can be found on GitHub.</p>
 <div class="section" id="section-2">
 <h2><a class="toc-backref" href="#toc-entry-13">13.0.1.0.0 (2020-06-11)</a></h2>
 <ul class="simple">
-<li>[MIG/REF] Migration of module to v13 and refactor (added new dedicated
-model for stock buffer).</li>
+<li>[MIG/REF] Migration of module to v13 and refactor (added new
+dedicated model for stock buffer).</li>
 </ul>
 </div>
 <div class="section" id="section-3">

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -509,10 +509,14 @@ class TestDdmrpCommon(common.TransactionCase):
         picking.action_confirm()
         return picking
 
-    def _do_picking(self, picking, date):
+    def _do_picking(self, picking, date, done_qty=None):
         """Do picking with only one move on the given date."""
         picking.action_confirm()
-        picking.move_ids.quantity = picking.move_ids.product_qty
+        if not done_qty:
+            done_qty = picking.move_ids.product_qty
+        else:
+            picking = picking.with_context(cancel_backorder=True)
+        picking.move_ids.quantity = done_qty
         picking.move_ids.picked = True
         picking._action_done()
         for move in picking.move_ids:

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -42,6 +42,19 @@ class TestDdmrp(TestDdmrpCommon):
         self.bufferModel.cron_ddmrp_adu()
         to_assert_value = (60 + 60) / 120  # Doesn't include inventory loss qty
         self.assertEqual(self.buffer_a.adu, to_assert_value)
+        # Create one more move in a different UoM but do not validate it fully
+        days = 90
+        date_move = self.calendar.plan_days(-1 * days - 1, datetime.today())
+        pick_out_3 = self.create_pickingoutA(date_move, 5, uom=self.dozen_unit)
+        self.assertEqual(pick_out_3.move_ids.product_uom_qty, 5.0)
+        self.assertEqual(pick_out_3.move_ids.product_qty, 60.0)
+        self._do_picking(pick_out_3, date_move, done_qty=2)
+        self.assertEqual(pick_out_3.state, "done")
+        self.assertEqual(pick_out_3.move_ids.quantity, 2.0)
+        self.assertEqual(pick_out_3.move_ids.product_uom_qty, 5.0)
+        to_assert_value = (60 + 60 + 24) / 120  # Only considers the done qty.
+        self.buffer_a._calc_adu()
+        self.assertEqual(self.buffer_a.adu, to_assert_value)
 
     def test_03_adu_calculation_window_past(self):
         """Test that the window considered to calculate the ADU is correct."""


### PR DESCRIPTION
Since v17, `quantity` field represents the actual done quantity and
can differ from `product_qty` which remeains as the original demand
when validating a transfer without a backorder. This need to be considered by ddmrp.

To do:

- [x] : Create a generic module that computes stock.move's `quantity` in the uom of the product.
- [x] : Use it here to fix the provided test case. 
