### PR TITLE
[18.0][FIX] ddmrp: set unique product default codes for tests

### DIFF
--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -199,7 +199,7 @@ class TestDdmrpCommon(common.TransactionCase):
                 "standard_price": 1,
                 "is_storable": True,
                 "uom_id": cls.uom_unit.id,
-                "default_code": "B",
+                "default_code": "B2",
                 "route_ids": [(6, 0, buy_route.ids)],
             }
         )


### PR DESCRIPTION
`product-code-unique` module in `product-attribute` adds a unique constraint to the product codes and when running tests with both modules installed, the test data creation fails in `common.py`
- https://github.com/OCA/product-attribute/blob/18.0/product_code_unique/models/product.py