### PR TITLE
[18.0][FIX] ddmrp: fix tests with unique default code (again)

### DIFF
--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -217,7 +217,7 @@ class TestDdmrpCommon(common.TransactionCase):
                 "name": "Product C",
                 "is_storable": True,
                 "uom_id": cls.uom_unit.id,
-                "default_code": "C",
+                "default_code": "C2",
                 "route_ids": [(6, 0, buy_route.ids)],
             }
         )


### PR DESCRIPTION
Previous commit changed one code but I forgot to check if it was the only one causing issues :man_facepalming: 
Previous PR
- https://github.com/OCA/ddmrp/pull/532

When unique constraint is set on product.product default_code the tests fail due to a duplicate default_code
