### PR TITLE
[17.0][IMP] ddmrp: consider that done quantity and demand can be different in stock.move

### DIFF
--- a/ddmrp/__manifest__.py
+++ b/ddmrp/__manifest__.py
@@ -20,6 +20,7 @@
         "base_cron_exclusion",
         "stock_warehouse_calendar",
         "stock_helper",
+        "stock_move_quantity_product_uom",
     ],
     "data": [
         "data/product_adu_calculation_method_data.xml",

--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1451,9 +1451,9 @@ class StockBuffer(models.Model):
         elif self.adu_calculation_method.source_past == "actual":
             domain = self._past_moves_domain(date_from, date_to, locations)
             for group in self.env["stock.move"].read_group(
-                domain, ["product_id", "product_qty"], ["product_id"]
+                domain, ["product_id", "quantity_product_uom"], ["product_id"]
             ):
-                qty += group["product_qty"]
+                qty += group["quantity_product_uom"]
         return qty / horizon
 
     def _get_horizon_adu_future_demand(self):

--- a/ddmrp/static/description/index.html
+++ b/ddmrp/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -677,9 +676,7 @@ by:</p>
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-23">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -507,10 +507,14 @@ class TestDdmrpCommon(common.TransactionCase):
         picking.action_confirm()
         return picking
 
-    def _do_picking(self, picking, date):
+    def _do_picking(self, picking, date, done_qty=None):
         """Do picking with only one move on the given date."""
         picking.action_confirm()
-        picking.move_ids.quantity = picking.move_ids.product_qty
+        if not done_qty:
+            done_qty = picking.move_ids.product_qty
+        else:
+            picking = picking.with_context(cancel_backorder=True)
+        picking.move_ids.quantity = done_qty
         picking.move_ids.picked = True
         picking._action_done()
         for move in picking.move_ids:

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -42,6 +42,19 @@ class TestDdmrp(TestDdmrpCommon):
         self.bufferModel.cron_ddmrp_adu()
         to_assert_value = (60 + 60) / 120  # Doesn't include inventory loss qty
         self.assertEqual(self.buffer_a.adu, to_assert_value)
+        # Create one more move in a different UoM but do not validate it fully
+        days = 90
+        date_move = self.calendar.plan_days(-1 * days - 1, datetime.today())
+        pick_out_3 = self.create_pickingoutA(date_move, 5, uom=self.dozen_unit)
+        self.assertEqual(pick_out_3.move_ids.product_uom_qty, 5.0)
+        self.assertEqual(pick_out_3.move_ids.product_qty, 60.0)
+        self._do_picking(pick_out_3, date_move, done_qty=2)
+        self.assertEqual(pick_out_3.state, "done")
+        self.assertEqual(pick_out_3.move_ids.quantity, 2.0)
+        self.assertEqual(pick_out_3.move_ids.product_uom_qty, 5.0)
+        to_assert_value = (60 + 60 + 24) / 120  # Only considers the done qty.
+        self.buffer_a._calc_adu()
+        self.assertEqual(self.buffer_a.adu, to_assert_value)
 
     def test_03_adu_calculation_window_past(self):
         """Test that the window considered to calculate the ADU is correct."""


### PR DESCRIPTION
Since v17, `quantity` field represents the actual done quantity and can differ from `product_qty` which remeains as the original demand when validating a transfer without a backorder. This need to be considered by ddmrp.

Backport from #528 

Depends on https://github.com/OCA/stock-logistics-workflow/pull/1939