### PR TITLE
[18.0][IMP] ddmrp: consider location_final_id

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1560,7 +1560,13 @@ class StockBuffer(models.Model):
         moves = self.env["stock.move"].search(domain)
         moves = moves.filtered(
             lambda move: move.location_id.is_sublocation_of(self.location_id)
-            and not move.location_dest_id.is_sublocation_of(self.location_id)
+            and (
+                not move.location_dest_id.is_sublocation_of(self.location_id)
+                or (
+                    move.location_final_id
+                    and not move.location_final_id.is_sublocation_of(self.location_id)
+                )
+            )
         )
         return moves
 
@@ -1588,7 +1594,13 @@ class StockBuffer(models.Model):
         moves = self.env["stock.move"].search(domain)
         moves = moves.filtered(
             lambda move: not move.location_id.is_sublocation_of(self.location_id)
-            and move.location_dest_id.is_sublocation_of(self.location_id)
+            and (
+                move.location_dest_id.is_sublocation_of(self.location_id)
+                or (
+                    move.location_final_id
+                    and move.location_final_id.is_sublocation_of(self.location_id)
+                )
+            )
         )
         return moves
 

--- a/ddmrp/tests/common.py
+++ b/ddmrp/tests/common.py
@@ -522,7 +522,7 @@ class TestDdmrpCommon(common.TransactionCase):
         for move in picking.move_ids:
             move.date = date
 
-    def create_orderpoint_procurement(self, buffer, make_procurement=True):
+    def create_buffer_procurement(self, buffer, make_procurement=True):
         """Make Procurement from Reordering Rule"""
         wizard = (
             self.make_procurement_wiz.with_user(self.user)
@@ -553,3 +553,27 @@ class TestDdmrpCommon(common.TransactionCase):
         move._action_confirm()
         move._action_done()
         move.date = date
+
+    @classmethod
+    def _run_procurement(
+        cls, product, location=None, product_qty=10.0, extra_values=None
+    ):
+        if not location:
+            location = cls.customer_location
+        values = {"warehouse_id": cls.warehouse}
+        if extra_values and isinstance(extra_values, dict):
+            values.update(extra_values)
+        return cls.env["procurement.group"].run(
+            [
+                cls.env["procurement.group"].Procurement(
+                    product,
+                    product_qty,
+                    product.uom_id,
+                    location,
+                    product.name,
+                    "/",
+                    cls.env.company,
+                    values,
+                )
+            ]
+        )

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -743,7 +743,7 @@ class TestDdmrp(TestDdmrpCommon):
 
         # Now we create a procurement order, based on the procurement
         # recommendation
-        self.create_orderpoint_procurement(self.buffer_a)
+        self.create_buffer_procurement(self.buffer_a)
         # should have generated a manufacturing order
         self.assertEqual(len(self.buffer_a.mrp_production_ids), 1)
         self.assertEqual(self.buffer_a.mrp_production_ids.product_qty, 40.0)
@@ -757,7 +757,7 @@ class TestDdmrp(TestDdmrpCommon):
         pol = self.pol_model.search([("product_id", "=", self.product_purchased.id)])
         self.assertFalse(pol)
         self.assertGreater(self.buffer_purchase.procure_recommended_qty, 0)
-        self.create_orderpoint_procurement(self.buffer_purchase)
+        self.create_buffer_procurement(self.buffer_purchase)
         pol = self.pol_model.search([("product_id", "=", self.product_purchased.id)])
         self.assertEqual(len(pol), 1)
         self.assertIn(pol.buffer_ids, self.buffer_purchase)
@@ -1317,3 +1317,131 @@ class TestDdmrp(TestDdmrpCommon):
             ]
         )
         self.assertTrue(op_nbp)
+
+    def test_47_incoming_quantity_from_final_location(self):
+        """Test that final location is considered in incoming calculation"""
+        # Enable 3 step routes
+        self.warehouse.write(
+            {
+                "delivery_steps": "pick_pack_ship",
+                "reception_steps": "three_steps",
+            }
+        )
+        # create incoming first step
+        self.assertEqual(self.buffer_purchase.procure_recommended_qty, 225)
+        self.create_buffer_procurement(self.buffer_purchase)
+        pol = self.env["purchase.order.line"].search(
+            [("product_id", "=", self.product_purchased.id)]
+        )
+        pol.order_id.button_confirm()
+        move = self.env["stock.move"].search(
+            [
+                ("product_id", "=", self.product_purchased.id),
+                ("location_id.usage", "!=", "internal"),
+            ]
+        )
+        self.assertEqual(len(move), 1)
+        self.assertEqual(move.location_dest_id, self.warehouse.wh_input_stock_loc_id)
+        self.assertEqual(move.location_final_id, self.warehouse.lot_stock_id)
+        self.assertEqual(move.product_qty, 225)
+        self.buffer_purchase.cron_actions()
+        self.assertEqual(self.buffer_purchase.incoming_dlt_qty, 225.0)
+        # Validating should generate the next picking.
+        self.assertFalse(move.move_dest_ids)
+        picking_1 = move.picking_id
+        self._do_picking(picking_1, datetime.today())
+        self.assertEqual(len(move.move_dest_ids), 1)
+        picking_2 = move.move_dest_ids.picking_id
+        move_2 = picking_2.move_ids
+        self.assertEqual(len(move_2), 1)
+        self.assertEqual(move_2.location_dest_id, self.warehouse.wh_qc_stock_loc_id)
+        self.assertEqual(move_2.location_final_id, self.warehouse.lot_stock_id)
+        self.buffer_purchase.cron_actions()
+        # Incoming qty should be the same.
+        self.assertEqual(self.buffer_purchase.incoming_dlt_qty, 225.0)
+
+        # Validating once again to generate the last picking.
+        self.assertFalse(move_2.move_dest_ids)
+        self._do_picking(picking_2, datetime.today())
+        self.assertEqual(len(move.move_dest_ids), 1)
+        picking_3 = move_2.move_dest_ids.picking_id
+        move_3 = picking_3.move_ids
+        self.assertEqual(len(move_3), 1)
+        self.assertEqual(move_3.location_dest_id, self.warehouse.lot_stock_id)
+        self.assertEqual(move_3.location_final_id, self.warehouse.lot_stock_id)
+        self.buffer_purchase.cron_actions()
+        # Incoming qty should be the same.
+        self.assertEqual(self.buffer_purchase.incoming_dlt_qty, 225.0)
+        # Validate last step should finally fill the buffer
+        self.assertEqual(self.buffer_purchase.product_location_qty_available_not_res, 0)
+        self._do_picking(picking_3, datetime.today())
+        self.buffer_purchase.cron_actions()
+        self.assertEqual(self.buffer_purchase.incoming_dlt_qty, 0)
+        self.assertEqual(
+            self.buffer_purchase.product_location_qty_available_not_res, 225
+        )
+
+    def test_48_outgoing_quantity_with_final_location(self):
+        """Test that final location is considered in incoming calculation"""
+        # Enable 3 step routes
+        self.warehouse.write(
+            {
+                "delivery_steps": "pick_pack_ship",
+                "reception_steps": "three_steps",
+            }
+        )
+        # Change buffer location to include intermediate locations.
+        # A planned operation from WH/stock to WH/Packing Zone should
+        # still be considered demand if the final destination is out of
+        # the buffer loc (case of standard deliver in 3-step route).
+        self.buffer_purchase.location_id = self.warehouse.view_location_id
+        self.buffer_purchase.cron_actions()
+        self.assertEqual(self.buffer_purchase.qualified_demand, 0.0)
+        # Create delivery first step
+        self._run_procurement(self.product_purchased)
+        move = self.env["stock.move"].search(
+            [("product_id", "=", self.product_purchased.id)]
+        )
+        self.assertEqual(len(move), 1)
+        self.assertEqual(move.location_dest_id, self.warehouse.wh_pack_stock_loc_id)
+        self.assertEqual(move.location_final_id, self.customer_location)
+        self.assertEqual(move.product_qty, 10)
+        self.buffer_purchase.cron_actions()
+        self.assertEqual(self.buffer_purchase.qualified_demand, 10.0)
+        # Validating should generate the next picking.
+        self.assertFalse(move.move_dest_ids)
+        picking_1 = move.picking_id
+        self._do_picking(picking_1, datetime.today())
+        self.assertEqual(len(move.move_dest_ids), 1)
+        picking_2 = move.move_dest_ids.picking_id
+        move_2 = picking_2.move_ids
+        self.assertEqual(len(move_2), 1)
+        self.assertEqual(move_2.location_dest_id, self.warehouse.wh_output_stock_loc_id)
+        self.assertEqual(move_2.location_final_id, self.customer_location)
+        move_2._do_unreserve()  # reserved moves are ignored by the buffer.
+        self.assertEqual(move_2.state, "confirmed")
+        self.buffer_purchase.cron_actions()
+        # demand qty should be the same.
+        self.assertEqual(self.buffer_purchase.qualified_demand, 10.0)
+        # Validating once again to generate the last picking.
+        self.assertFalse(move_2.move_dest_ids)
+        self._do_picking(picking_2, datetime.today())
+        self.assertEqual(len(move.move_dest_ids), 1)
+        picking_3 = move_2.move_dest_ids.picking_id
+        move_3 = picking_3.move_ids
+        self.assertEqual(len(move_3), 1)
+        self.assertEqual(move_3.location_dest_id, self.customer_location)
+        self.assertEqual(move_3.location_final_id, self.customer_location)
+        move_3._do_unreserve()
+        self.assertEqual(move_3.state, "confirmed")
+        self.buffer_purchase.cron_actions()
+        # outgoing qty should be the same.
+        self.assertEqual(self.buffer_purchase.qualified_demand, 10.0)
+        # Validate last step should finally deplete the buffer
+        self.assertEqual(self.buffer_purchase.product_location_qty_available_not_res, 0)
+        self._do_picking(picking_3, datetime.today())
+        self.buffer_purchase.cron_actions()
+        self.assertEqual(self.buffer_purchase.qualified_demand, 0)
+        self.assertEqual(
+            self.buffer_purchase.product_location_qty_available_not_res, -10
+        )

--- a/ddmrp/tests/test_ddmrp_distributed_source_location.py
+++ b/ddmrp/tests/test_ddmrp_distributed_source_location.py
@@ -116,9 +116,7 @@ class TestDdmrpDistributedSourceLocation(TestDdmrpCommon):
         # applied)
         self.buffer_dist.procure_recommended_qty = 10000
 
-        return self.create_orderpoint_procurement(
-            self.buffer_dist, make_procurement=False
-        )
+        return self.create_buffer_procurement(self.buffer_dist, make_procurement=False)
 
     def test_distributed_source_limit_replenish(self):
         wizard = self._set_qty_and_create_replenish_wizard()

--- a/ddmrp/tests/test_distributed_max_proc_time.py
+++ b/ddmrp/tests/test_distributed_max_proc_time.py
@@ -89,7 +89,7 @@ class TestDdmrpMaxProcTime(TestDdmrpCommon):
         # lie about the recommended qty to force creation of replenishment
         self.buffer_dist.procure_recommended_qty = 10000
 
-        self.create_orderpoint_procurement(self.buffer_dist)
+        self.create_buffer_procurement(self.buffer_dist)
         moves = self.env["stock.move"].search(
             [("product_id", "=", self.product_c_green.id)]
         )
@@ -113,7 +113,7 @@ class TestDdmrpMaxProcTime(TestDdmrpCommon):
         # lie about the recommended qty to force creation of replenishment
         self.buffer_dist.procure_recommended_qty = 10000
 
-        self.create_orderpoint_procurement(self.buffer_dist)
+        self.create_buffer_procurement(self.buffer_dist)
         moves = self.env["stock.move"].search(
             [("product_id", "=", self.product_c_green.id)]
         )


### PR DESCRIPTION
Since v18, routes in several steps can be configured to delay the creation of next steps. This is the case for standard multi step routes for incoming and outgoing. We need to account for that in incoming and qualified demand calculation.