### PR TITLE
[16.0][IMP] ddmrp: buffers accesible from product template form view

### DIFF
--- a/ddmrp/models/product_template.py
+++ b/ddmrp/models/product_template.py
@@ -1,12 +1,20 @@
 # Copyright 2019-20 ForgeFlow S.L. (http://www.forgeflow.com)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
-from odoo import _, api, models
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
+
+    buffer_count = fields.Integer(compute="_compute_buffer_count")
+
+    def _compute_buffer_count(self):
+        for rec in self:
+            rec.buffer_count = sum(
+                variant.buffer_count for variant in rec.product_variant_ids
+            )
 
     # UOM: (stock_orderpoint_uom):
     @api.constrains("uom_id")
@@ -26,3 +34,6 @@ class ProductTemplate(models.Model):
                         "different Procurement unit of measure category."
                     )
                 )
+
+    def action_view_stock_buffers(self):
+        return self.product_variant_ids.action_view_stock_buffers()

--- a/ddmrp/views/product_view.xml
+++ b/ddmrp/views/product_view.xml
@@ -27,4 +27,29 @@
         </field>
     </record>
 
+    <record id="product_template_only_form_view_inherit" model="ir.ui.view">
+        <field name="name">product.template.product.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//div[@name='button_box']/button[@name='action_view_mrp_area_parameters']"
+                position="after"
+            >
+                <button
+                    type="object"
+                    name="action_view_stock_buffers"
+                    class="oe_stat_button"
+                    icon="fa-flask"
+                    attrs="{'invisible': [('buffer_count', '=', 0)]}"
+                >
+                    <field
+                        name="buffer_count"
+                        widget="statinfo"
+                        string="Stock Buffers"
+                    />
+                </button>
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
With this change, it is possible to access the buffers of the variants of a product template from the form view.

BP of https://github.com/OCA/ddmrp/pull/536

@ForgeFlow 