### PR TITLE
[16.0][FIX] ddmrp_adjustment: clean `parent_daf_applied` before recomputing

### DIFF
--- a/ddmrp_adjustment/models/stock_buffer.py
+++ b/ddmrp_adjustment/models/stock_buffer.py
@@ -143,7 +143,10 @@ class StockBuffer(models.Model):
         components after the cron update of all the buffers."""
         res = super().cron_ddmrp_adu(automatic)
         today = fields.Date.today()
-        for op in self.search([]).filtered("extra_demand_ids"):
+        self.search(
+            [("parent_daf_applied", "!=", -1), ("extra_demand_ids", "=", False)]
+        ).write({"parent_daf_applied": -1})
+        for op in self.search([("extra_demand_ids", "!=", False)]):
             op.parent_daf_applied = -1
             daf_parent = sum(
                 op.extra_demand_ids.filtered(


### PR DESCRIPTION
Otherwise, previous extra demand was showed in the view but not really applying.

![2025-06-23_13-19](https://github.com/user-attachments/assets/ba8704d7-2900-43b1-8e25-4a494b598c97)

on click (no extra demand from DAFs):
![2025-06-23_13-20](https://github.com/user-attachments/assets/22ba2681-0f09-4da8-8da3-6b1394c420f2)


Also, avoid `filtered` of all buffers for performance reasons.