### PR TITLE
[18.0][IMP] ddmrp_exclude_moves_adu_calc: ease access to  excluded moves

### DIFF
--- a/ddmrp_exclude_moves_adu_calc/README.rst
+++ b/ddmrp_exclude_moves_adu_calc/README.rst
@@ -31,8 +31,8 @@ DDMRP Exclude Moves ADU Calc
 This module adds new criteria to exclude moves from the calculation of
 the Average Daily Usage (ADU) on a Buffer, based on:
 
-- Locations
-- Specific stock moves
+-  Locations
+-  Specific stock moves
 
 **Table of contents**
 
@@ -44,24 +44,17 @@ Usage
 
 You can exclude specific moves or all moves towards a specific location:
 
-- Go to *Inventory > Reports > Stock Moves* and click on *Action >
-  Exclude from ADU* for a specific move or several.
-- Go to *Inventory > Configuration > WH Management > Locations* and
-  check the flag *Exclude this location from ADU calculation* for the
-  desired locations.
+-  Go to *Inventory > Reports > Stock Moves* and click on *Action >
+   Exclude from ADU* for a specific move or several.
+-  Go to *Inventory > Configuration > WH Management > Locations* and
+   check the flag *Exclude this location from ADU calculation* for the
+   desired locations.
 
 Changelog
 =========
 
-13.0.1.0.0 (2021-03-15)
------------------------
-
-- Standard migration of the module to v13.
-
-11.0.1.0.0 (2018-09-17)
------------------------
-
-- Start of history. Migrated to OCA/ddmrp.
+Follow the history of changes in `GitHub Pull
+Requests <https://github.com/OCA/ddmrp/pulls?q=is%3Apr+ddmrp_exclude_moves_adu_calc+is%3Aclosed>`__.
 
 Bug Tracker
 ===========
@@ -84,13 +77,13 @@ Authors
 Contributors
 ------------
 
-- Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
+-  Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
 
-- Lois Rilo Antelo <lois.rilo@forgeflow.com>
+-  Lois Rilo Antelo <lois.rilo@forgeflow.com>
 
-- `Trobz <https://trobz.com>`__:
+-  `Trobz <https://trobz.com>`__:
 
-  - Khoi Vo <khoivha@trobz.com>
+   -  Khoi Vo <khoivha@trobz.com>
 
 Other credits
 -------------

--- a/ddmrp_exclude_moves_adu_calc/models/stock_buffer.py
+++ b/ddmrp_exclude_moves_adu_calc/models/stock_buffer.py
@@ -15,7 +15,19 @@ class StockBuffer(models.Model):
     def _past_moves_domain(self, date_from, date_to, locations):
         new_locs = locations.filtered(lambda loc: not loc.exclude_from_adu)
         res = super()._past_moves_domain(date_from, date_to, new_locs)
+        if self.env.context.get("ddmrp_move_include_excluded"):
+            return res
         exclude_moves = self.env["stock.move"].search(self._exclude_past_moves_domain())
         if exclude_moves:
             res.append(("id", "not in", exclude_moves.ids))
+        return res
+
+    def action_view_past_adu_direct_demand(self):
+        res = super(
+            StockBuffer, self.with_context(ddmrp_move_include_excluded=True)
+        ).action_view_past_adu_direct_demand()
+        if self.adu_calculation_method.source_past == "actual":
+            ctx = res.get("context", {})
+            ctx["search_default_not_excluded_from_adu"] = True
+            res["context"] = ctx
         return res

--- a/ddmrp_exclude_moves_adu_calc/readme/HISTORY.md
+++ b/ddmrp_exclude_moves_adu_calc/readme/HISTORY.md
@@ -1,7 +1,1 @@
-## 13.0.1.0.0 (2021-03-15)
-
-- Standard migration of the module to v13.
-
-## 11.0.1.0.0 (2018-09-17)
-
-- Start of history. Migrated to OCA/ddmrp.
+Follow the history of changes in [GitHub Pull Requests](https://github.com/OCA/ddmrp/pulls?q=is%3Apr+ddmrp_exclude_moves_adu_calc+is%3Aclosed).

--- a/ddmrp_exclude_moves_adu_calc/static/description/index.html
+++ b/ddmrp_exclude_moves_adu_calc/static/description/index.html
@@ -380,17 +380,13 @@ the Average Daily Usage (ADU) on a Buffer, based on:</p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#usage" id="toc-entry-1">Usage</a></li>
-<li><a class="reference internal" href="#changelog" id="toc-entry-2">Changelog</a><ul>
-<li><a class="reference internal" href="#section-1" id="toc-entry-3">13.0.1.0.0 (2021-03-15)</a></li>
-<li><a class="reference internal" href="#section-2" id="toc-entry-4">11.0.1.0.0 (2018-09-17)</a></li>
-</ul>
-</li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-5">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-6">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-7">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-8">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="toc-entry-9">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-10">Maintainers</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-2">Changelog</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-7">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -408,21 +404,11 @@ desired locations.</li>
 </div>
 <div class="section" id="changelog">
 <h1><a class="toc-backref" href="#toc-entry-2">Changelog</a></h1>
-<div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-3">13.0.1.0.0 (2021-03-15)</a></h2>
-<ul class="simple">
-<li>Standard migration of the module to v13.</li>
-</ul>
-</div>
-<div class="section" id="section-2">
-<h2><a class="toc-backref" href="#toc-entry-4">11.0.1.0.0 (2018-09-17)</a></h2>
-<ul class="simple">
-<li>Start of history. Migrated to OCA/ddmrp.</li>
-</ul>
-</div>
+<p>Follow the history of changes in <a class="reference external" href="https://github.com/OCA/ddmrp/pulls?q=is%3Apr+ddmrp_exclude_moves_adu_calc+is%3Aclosed">GitHub Pull
+Requests</a>.</p>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-5">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/ddmrp/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -430,15 +416,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-6">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-7">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>ForgeFlow</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-8">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
 <ul class="simple">
 <li>Jordi Ballester Alomar &lt;<a class="reference external" href="mailto:jordi.ballester&#64;forgeflow.com">jordi.ballester&#64;forgeflow.com</a>&gt;</li>
 <li>Lois Rilo Antelo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
@@ -449,12 +435,12 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#toc-entry-9">Other credits</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Other credits</a></h2>
 <p>The migration of this module from 13.0 to 14.0 was financially supported
 by Camptocamp</p>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-10">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/ddmrp_exclude_moves_adu_calc/tests/test_ddmrp.py
+++ b/ddmrp_exclude_moves_adu_calc/tests/test_ddmrp.py
@@ -211,3 +211,10 @@ class TestDdmrp(common.TransactionCase):
             move.exclude_from_adu = True
         to_assert_value = 60 / 120
         self.assertEqual(buffer_a.adu, to_assert_value)
+
+        # Test action:
+        action_dict = buffer_a.action_view_past_adu_direct_demand()
+        self.assertEqual(
+            action_dict["domain"][0][2], [pick_excluded.move_ids.id, pick_a.move_ids.id]
+        )
+        self.assertIn("search_default_not_excluded_from_adu", action_dict["context"])

--- a/ddmrp_exclude_moves_adu_calc/views/stock_move_view.xml
+++ b/ddmrp_exclude_moves_adu_calc/views/stock_move_view.xml
@@ -17,4 +17,32 @@
         <field name="state">code</field>
         <field name="code">records._toggle_exclude_from_adu()</field>
     </record>
+    <record id="view_move_tree" model="ir.ui.view">
+        <field name="name">stock.move.tree - ddmrp_exclude_moves_adu_calc</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_move_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field name="exclude_from_adu" invisible="1" />
+            </xpath>
+            <list position="attributes">
+                <attribute name="decoration-muted">exclude_from_adu == True</attribute>
+            </list>
+        </field>
+    </record>
+    <record id="view_move_search" model="ir.ui.view">
+        <field name="name">stock.move.search - ddmrp_exclude_moves_adu_calc</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_move_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='inventory']" position="after">
+                <separator />
+                <filter
+                    string="Not Excluded from ADU"
+                    name="not_excluded_from_adu"
+                    domain="[('exclude_from_adu', '=', False)]"
+                />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
You can now access excluded moves via the ADU past source details only removing the default filter.

Take the ocassion to simplify history section in readme.

Fwport of #549