### PR TITLE
[18.0][IMP] ddmrp: create a ddmrp section in warehouse view

### DIFF
--- a/ddmrp/views/stock_warehouse_views.xml
+++ b/ddmrp/views/stock_warehouse_views.xml
@@ -7,9 +7,11 @@
         <field name="model">stock.warehouse</field>
         <field name="inherit_id" ref="stock.view_warehouse" />
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
-                <field name="nfp_incoming_safety_factor" />
-            </field>
+            <xpath expr="//page[@name='warehouse_config']/group" position="inside">
+                <group name="ddmrp" string="DDMRP">
+                    <field name="nfp_incoming_safety_factor" />
+                </group>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
These are secondary warehouse configurations and not something that fits on the header of the warehouse form.

New position:

<img width="1169" height="731" alt="image" src="https://github.com/user-attachments/assets/58ce7a3a-8702-49a2-8b55-b2f083b6afef" />
