### PR TITLE
[18.0][FIX] ddmrp: consider location_final_id in NFP auto update

### DIFF
--- a/ddmrp/models/stock_move.py
+++ b/ddmrp/models/stock_move.py
@@ -61,15 +61,31 @@ class StockMove(models.Model):
         out_buffers = in_buffers = self.env["stock.buffer"]
         for move in self:
             out_buffers |= move.mapped("product_id.buffer_ids").filtered(
-                lambda buffer: (
-                    move.location_id.is_sublocation_of(buffer.location_id)  # noqa: B023
-                    and not move.location_dest_id.is_sublocation_of(buffer.location_id)  # noqa: B023
+                lambda buffer, move=move: (
+                    move.location_id.is_sublocation_of(buffer.location_id)
+                    and (
+                        not move.location_dest_id.is_sublocation_of(buffer.location_id)
+                        or (
+                            move.location_final_id
+                            and not move.location_final_id.is_sublocation_of(
+                                buffer.location_id
+                            )
+                        )
+                    )
                 )
             )
             in_buffers |= move.mapped("product_id.buffer_ids").filtered(
-                lambda buffer: (
-                    not move.location_id.is_sublocation_of(buffer.location_id)  # noqa: B023
-                    and move.location_dest_id.is_sublocation_of(buffer.location_id)  # noqa: B023
+                lambda buffer, move=move: (
+                    not move.location_id.is_sublocation_of(buffer.location_id)
+                    and (
+                        move.location_dest_id.is_sublocation_of(buffer.location_id)
+                        or (
+                            move.location_final_id
+                            and move.location_final_id.is_sublocation_of(
+                                buffer.location_id
+                            )
+                        )
+                    )
                 )
             )
         return out_buffers, in_buffers

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -1344,6 +1344,12 @@ class TestDdmrp(TestDdmrpCommon):
         self.assertEqual(move.location_dest_id, self.warehouse.wh_input_stock_loc_id)
         self.assertEqual(move.location_final_id, self.warehouse.lot_stock_id)
         self.assertEqual(move.product_qty, 225)
+        _ob, in_buffers = move._find_buffers_to_update_nfp()
+        self.assertIn(
+            self.buffer_purchase,
+            in_buffers,
+            "Buffer won't be found for auto-NFP update",
+        )
         self.buffer_purchase.cron_actions()
         self.assertEqual(self.buffer_purchase.incoming_dlt_qty, 225.0)
         # Validating should generate the next picking.
@@ -1411,6 +1417,12 @@ class TestDdmrp(TestDdmrpCommon):
         # Validating should generate the next picking.
         self.assertFalse(move.move_dest_ids)
         picking_1 = move.picking_id
+        out_buffers, _ib = move._find_buffers_to_update_nfp()
+        self.assertIn(
+            self.buffer_purchase,
+            out_buffers,
+            "Buffer won't be found for auto-NFP update",
+        )
         self._do_picking(picking_1, datetime.today())
         self.assertEqual(len(move.move_dest_ids), 1)
         picking_2 = move.move_dest_ids.picking_id


### PR DESCRIPTION
Otherwise, we can have situation in which some incoming qty is not considered after generating supply and lead to duplicated procurements the next time the buffer refreshes from a demand change (if only_nfp == "out").

Also, the opposite case is possible for demand.