### PR TITLE
[18.0][PERF] ddmrp_history: Improve domain of multicompany ir rule

### DIFF
--- a/ddmrp_history/security/security.xml
+++ b/ddmrp_history/security/security.xml
@@ -6,8 +6,6 @@
         <field name="name">DDMRP History Multi-Company</field>
         <field name="model_id" ref="model_ddmrp_history" />
         <field eval="True" name="global" />
-        <field
-            name="domain_force"
-        >['|',('company_id', 'in', company_ids),('company_id','=',False)]</field>
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
     </record>
 </odoo>


### PR DESCRIPTION
Field company_id on ddmrp.history is defined as a related to buffer_id.company_id which is a required field on stock.buffer.

Therefore, we do not need to consider the possibility of a null value in the rule, which will in turn improve how Odoo's ORM will generate the SQL to fetch records linked to a single buffer.

In a table with >30M records and 2000 linked to a single buffer, execution time went from 10-15ms to 3-5ms to get all the records from a single buffer.