### PR TITLE
[18.0][FIX] ddmrp: bom line buffered

### DIFF
--- a/ddmrp/models/mrp_bom.py
+++ b/ddmrp/models/mrp_bom.py
@@ -167,7 +167,7 @@ class MrpBomLine(models.Model):
             product = self.product_tmpl_id.product_variant_ids[0]
         domain = [
             ("product_id", "=", product.id),
-            ("location_id", "=", self.context_location_id.id),
+            ("location_id", "child_of", self.context_location_id.id),
         ]
         if self.company_id:
             domain.append(("company_id", "=", self.company_id.id))


### PR DESCRIPTION
Consider a bom line as buffered if there is a buffer on a child location

Use case:
* Have pick that sources products from several locations under "Production" location
* Have a manufactured buffer on that "Production" location
* Have distributed buffers for the components on the "Production/Shelf" location

The bom should consider the bom lines as buffered. This has an impact on the dlt computation.

Components are located on different areas under "Production" and the buffer is on the area where the component must be replenished

cc @LoisRForgeFlow @BernatPForgeFlow 

Manually tested