### PR TITLE
[18.0][IMP] ddmrp_exclude_moves_adu_calc: replace `.filtered` by `.search` for better perf

### DIFF
--- a/ddmrp_exclude_moves_adu_calc/models/stock_buffer.py
+++ b/ddmrp_exclude_moves_adu_calc/models/stock_buffer.py
@@ -13,7 +13,13 @@ class StockBuffer(models.Model):
 
     @api.model
     def _past_moves_domain(self, date_from, date_to, locations):
-        new_locs = locations.filtered(lambda loc: not loc.exclude_from_adu)
+        # NOTE: do not use .filtered(...) for two reasons:
+        #   - number of locations could be high
+        #   - prefetch is retrieving too much columns when accessing .exclude_from_adu
+        #     (with_prefetch=False improves a bit, but not as much as a search)
+        new_locs = self.env["stock.location"].search(
+            [("id", "in", locations.ids), ("exclude_from_adu", "=", False)]
+        )
         res = super()._past_moves_domain(date_from, date_to, new_locs)
         if self.env.context.get("ddmrp_move_include_excluded"):
             return res


### PR DESCRIPTION
For our use case, this divided by x2.5 the time required to process 10k+ buffers, with 30k+ locations (through `queue_job`).

## Before:
<img width="911" height="582" alt="image" src="https://github.com/user-attachments/assets/fc358c3f-7ea0-4e72-93ee-52a2d7e2f159" />

## After:
<img width="912" height="608" alt="image" src="https://github.com/user-attachments/assets/2e660056-2041-41b9-a19f-289772d7b06a" />