### PR TITLE
[18.0][FIX] ddmrp: fix _calc_incoming_dld_qty and _calc_qualified_demand

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1572,6 +1572,11 @@ class StockBuffer(models.Model):
                 or (
                     move.location_final_id
                     and not move.location_final_id.is_sublocation_of(self.location_id)
+                    and not move.move_dest_ids.filtered(
+                        lambda m: m.location_final_id == move.location_final_id
+                        and m.state
+                        in ("waiting", "confirmed", "partially_available", "assigned")
+                    )
                 )
             )
         )
@@ -1606,6 +1611,11 @@ class StockBuffer(models.Model):
                 or (
                     move.location_final_id
                     and move.location_final_id.is_sublocation_of(self.location_id)
+                    and not move.move_dest_ids.filtered(
+                        lambda m: m.location_final_id == move.location_final_id
+                        and m.state
+                        in ("waiting", "confirmed", "partially_available", "assigned")
+                    )
                 )
             )
         )


### PR DESCRIPTION
In https://github.com/OCA/ddmrp/pull/535 a fix was introduced to take info account moves which have the stock.buffer's location in their final destination. This introduced a bug when different chained moves are moving a product towards its buffer location, as all the moves will be counted, resulting in a wrong net flow position (among others).

I propose to fix this with the following check: if a move with the final destination under the buffer's location has a matching final destination, and there are pending chained moves with the same final destination, these moves will be in our list: the current move needs to be disregarded.

We may still have a problem if the there are some cancelled moves and the total quantity does not match the original expected quantity, but this should be rare, so I'm not considering this in the current PR.