### PR TITLE
[18.0][FIX] ddmrp: Use supplier from product template for vendor code compute

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1036,7 +1036,7 @@ class StockBuffer(models.Model):
                 continue
             supplier_info = rec._get_product_sellers().filtered(
                 lambda r: r.partner_id == rec.main_supplier_id  # noqa: B023
-                and r.product_id == rec.product_id  # noqa: B023
+                and (not r.product_id or r.product_id == rec.product_id)  # noqa: B023
             )
             rec.product_vendor_code = fields.first(supplier_info).product_code
 


### PR DESCRIPTION
In case the product set on the buffer only has a supplier info set at product template level and not on the product variant itself, the product's vendor code was not set on the buffer.