### PR TITLE
[16.0][FIX] ddmrp_sale: can_server_sale in multi step deliveries + cancelled moves

### DIFF
--- a/ddmrp_sale/models/stock_buffer.py
+++ b/ddmrp_sale/models/stock_buffer.py
@@ -15,23 +15,40 @@ class StockBuffer(models.Model):
         comodel_name="sale.order.line",
     )
 
-    def _get_sale_source_location(self):
+    def _get_sale_source_location(self, proc_locs):
+        # Adapting this method to be very similar to _get_source_location_from_route
+        # from stock_helper but not using that as it disappears in future versions and
+        # we don't want to add dependency to the new module.
         self.ensure_one()
-        proc_loc = self.env.ref("stock.stock_location_customers")
         values = {
             "warehouse_id": self.warehouse_id,
             "company_id": self.company_id,
         }
-        rule = self.env["procurement.group"]._get_rule(
-            self.product_id, proc_loc, values
-        )
-        return rule and rule.location_src_id
+        sale_source_locations = self.env["stock.location"]
+        for proc_loc in proc_locs:
+            current_location = proc_loc
+            while current_location:
+                rule = self.env["procurement.group"]._get_rule(
+                    self.product_id, current_location, values
+                )
+                if not rule:
+                    break
+                if rule.procure_method == "make_to_stock":
+                    sale_source_locations |= rule.location_src_id
+                    break
+                if rule.location_src_id == current_location:
+                    break
+                current_location = rule.location_src_id
+        return sale_source_locations
 
     @api.depends("warehouse_id", "location_id")
     def _compute_can_serve_sales(self):
+        proc_locations = self.env["stock.location"].search([("usage", "=", "customer")])
         for rec in self:
-            loc = rec._get_sale_source_location()
-            rec.can_serve_sales = loc.is_sublocation_of(rec.location_id)
+            locs = rec._get_sale_source_location(proc_locations)
+            rec.can_serve_sales = any(
+                [loc.is_sublocation_of(rec.location_id) for loc in locs]
+            )
 
     def _search_sales_qualified_demand_domain(self):
         self.ensure_one()

--- a/ddmrp_sale/models/stock_buffer.py
+++ b/ddmrp_sale/models/stock_buffer.py
@@ -63,7 +63,6 @@ class StockBuffer(models.Model):
             ),
             ("commitment_date", "<=", date_to),
             ("order_id.warehouse_id", "=", self.warehouse_id.id),
-            ("move_ids", "=", False),
         ]
 
     def _search_sales_qualified_demand(self):

--- a/ddmrp_sale/tests/test_ddmrp_sale.py
+++ b/ddmrp_sale/tests/test_ddmrp_sale.py
@@ -39,6 +39,9 @@ class TestDDMRPSale(TestDdmrpCommon):
     def test_01_can_serve_sales(self):
         self.assertTrue(self.buffer_a.can_serve_sales)
         self.assertFalse(self.buffer_internal.can_serve_sales)
+        self.warehouse.delivery_steps = "pick_pack_ship"
+        self.buffer_a._compute_can_serve_sales()
+        self.assertTrue(self.buffer_a.can_serve_sales)
 
     def test_02_sales_quotation_included_as_demand(self):
         self._refresh_involved_buffers()

--- a/ddmrp_sale/tests/test_ddmrp_sale.py
+++ b/ddmrp_sale/tests/test_ddmrp_sale.py
@@ -116,3 +116,69 @@ class TestDDMRPSale(TestDdmrpCommon):
         self._refresh_involved_buffers()
         diff = self.buffer_a.qualified_demand - self.buffer_internal.qualified_demand
         self.assertEqual(diff, 24)
+
+    def test_04_sales_quotation_canceled_included_as_demand(self):
+        """
+        The quotation is canceled and therefore its stock.moves canceled, so we can take
+        into account the quotation if it's set as draft again.
+
+        You cannot cancel a sale order if it has done moves.
+        """
+        self._refresh_involved_buffers()
+        self.assertEqual(
+            self.buffer_a.qualified_demand, self.buffer_internal.qualified_demand
+        )
+        so_date = dt.today() + td(days=2)
+        so = self.so_model.create(
+            {
+                "partner_id": self.customer.id,
+                "partner_invoice_id": self.customer.id,
+                "partner_shipping_id": self.customer.id,
+                "commitment_date": so_date,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.productA.id,
+                            "name": "cool product",
+                            "price_unit": 100.0,
+                            "product_uom_qty": 17,  # it is a spike.
+                            "commitment_date": so_date,
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(so.state, "draft")
+        self._refresh_involved_buffers()
+        self.assertNotEqual(
+            self.buffer_a.qualified_demand, self.buffer_internal.qualified_demand
+        )
+        # Buffer A sees quotations because it can serve SO's.
+        diff = self.buffer_a.qualified_demand - self.buffer_internal.qualified_demand
+        self.assertEqual(diff, 17)
+        so.action_confirm()
+        self.assertTrue(so.order_line.move_ids)
+        self._refresh_involved_buffers()
+        self.assertEqual(
+            self.buffer_a.qualified_demand, self.buffer_internal.qualified_demand
+        )
+        so._action_cancel()
+        so.action_draft()
+        self.assertEqual(so.state, "draft")
+        self._refresh_involved_buffers()
+        self.assertNotEqual(
+            self.buffer_a.qualified_demand, self.buffer_internal.qualified_demand
+        )
+        diff = self.buffer_a.qualified_demand - self.buffer_internal.qualified_demand
+        buffer_a_prev_nfp = self.buffer_a.net_flow_position
+        buffer_internal_prev_nfp = self.buffer_internal.net_flow_position
+        self.assertEqual(diff, 17)
+        so.action_confirm()
+        self.assertTrue(so.picking_ids)
+        self._refresh_involved_buffers()
+        self.assertEqual(self.buffer_a.net_flow_position, buffer_a_prev_nfp)
+        self.assertEqual(
+            buffer_internal_prev_nfp - self.buffer_internal.net_flow_position, 17
+        )


### PR DESCRIPTION
Adapt the computation of can_serve_sale as there are some cases in which the buffer cannot be detected if, for example, the sale route is in more than 1 step. We do not use the method in stock_helper as it disappears in future versions and we don't want to add dependency to the new module.

When a quotation is canceled and  its stock.moves are canceled, so we can take into account quotations with moves (as they must be canceled). You cannot cancel a sale order if it has done moves.