### PR TITLE
[17.0][FIX] ddmrp: hide misleading ADU details buttons when not relevant

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1095,6 +1095,12 @@ class StockBuffer(models.Model):
     adu_calculation_method_type = fields.Selection(
         related="adu_calculation_method.method",
     )
+    adu_calculation_method_source_past = fields.Selection(
+        related="adu_calculation_method.source_past",
+    )
+    adu_calculation_method_source_future = fields.Selection(
+        related="adu_calculation_method.source_future",
+    )
     adu_fixed = fields.Float(
         string="Fixed ADU",
         default=1.0,

--- a/ddmrp/views/stock_buffer_view.xml
+++ b/ddmrp/views/stock_buffer_view.xml
@@ -247,6 +247,14 @@
                                     invisible="1"
                                 />
                                 <field
+                                    name="adu_calculation_method_source_past"
+                                    invisible="1"
+                                />
+                                <field
+                                    name="adu_calculation_method_source_future"
+                                    invisible="1"
+                                />
+                                <field
                                     name="adu_fixed"
                                     invisible="adu_calculation_method_type != 'fixed'"
                                 />
@@ -269,7 +277,7 @@
                                         name="action_view_past_adu_indirect_demand"
                                         icon="fa-search"
                                         type="object"
-                                        invisible="adu_calculation_method_type in ['fixed', 'future'] or used_in_bom_count == 0 or adu == 0"
+                                        invisible="adu_calculation_method_type in ['fixed', 'future'] or adu_calculation_method_source_past != 'estimates_mrp' or used_in_bom_count == 0 or adu == 0"
                                     />
                                     <button
                                         title="View ADU (Future - Direct Demand)"
@@ -283,7 +291,7 @@
                                         name="action_view_future_adu_indirect_demand"
                                         icon="fa-search"
                                         type="object"
-                                        invisible="adu_calculation_method_type in ['fixed', 'past'] or used_in_bom_count == 0 or adu == 0"
+                                        invisible="adu_calculation_method_type in ['fixed', 'past'] or adu_calculation_method_source_future != 'estimates_mrp' or used_in_bom_count == 0 or adu == 0"
                                     />
                                 </div>
                                 <field


### PR DESCRIPTION
Show only indirect demand button when the method is going to use it.

Fwport #594 