### PR TITLE
[17.0][FIX] ddmrp: propoer rounding for TOY2 in execution buffer

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -724,7 +724,10 @@ class StockBuffer(models.Model):
             precision_rounding=self.product_uom.rounding,
         )
         tor2_exec = self.top_of_green
-        toy2_exec = (tor2_exec + tog_exec) / 2
+        toy2_exec = float_round(
+            (tor2_exec + tog_exec) / 2,
+            precision_rounding=self.product_uom.rounding,
+        )
         hex_colors = self._get_colors_hex_map(pallete="execution")
         red = p.vbar(
             x=1,


### PR DESCRIPTION
Backport https://github.com/OCA/ddmrp/pull/601