### PR TITLE
[18.0][FIX] ddmrp_report_part_flow_index: do not include archived buffers in the report

### DIFF
--- a/ddmrp_report_part_flow_index/reports/report_ddmrp_part_plan_flow_index.py
+++ b/ddmrp_report_part_flow_index/reports/report_ddmrp_part_plan_flow_index.py
@@ -67,12 +67,17 @@ class ReportDdmrpPartsPlanFlowIndex(models.Model):
         """
         return select_str
 
+    @api.model
+    def _sub_where(self):
+        return "WHERE active IS TRUE"
+
     @property
     def _table_query(self):
         return f"""
                 WITH a AS
                     (SELECT {self._sub_select()}
-                     FROM stock_buffer)
+                     FROM stock_buffer
+                     {self._sub_where()})
                 SELECT
                     {self._select()}
                 FROM a

--- a/ddmrp_report_part_flow_index/reports/report_ddmrp_part_plan_flow_index_views.xml
+++ b/ddmrp_report_part_flow_index/reports/report_ddmrp_part_plan_flow_index_views.xml
@@ -28,7 +28,7 @@
         <field name="model">report.ddmrp.part.plan.flow.index</field>
         <field name="arch" type="xml">
             <list name="Parts Plan Flow Index">
-                <field name="buffer_id" />
+                <field name="buffer_id" widget="many2one" />
                 <field name="product_id" />
                 <field name="location_id" />
                 <field name="green_zone_qty" />

--- a/ddmrp_report_part_flow_index/tests/test_ddmrp_report_part_flow_index.py
+++ b/ddmrp_report_part_flow_index/tests/test_ddmrp_report_part_flow_index.py
@@ -55,3 +55,12 @@ class TestDDMRPReportPartFlowIndex(TransactionCase):
             self.flow_index_group_2,
             "Flow index group was not updated correctly!",
         )
+
+    def test_02_archived_buffers_excluded(self):
+        """Archived buffers must not appear in the report"""
+        self.buffer.cron_actions()
+        report = self.env["report.ddmrp.part.plan.flow.index"]
+        self.assertTrue(report.search([("buffer_id", "=", self.buffer.id)]))
+        self.buffer.toggle_active()
+        self.env.invalidate_all()
+        self.assertFalse(report.search([("buffer_id", "=", self.buffer.id)]))


### PR DESCRIPTION
Also, take the ocassion to make buffer_id clickable in tree view.