### PR TITLE
[16.0][FIX] ddmrp_report_part_flow_index: do not include archived buffers in the report

### DIFF
--- a/ddmrp_report_part_flow_index/reports/report_ddmrp_part_plan_flow_index.py
+++ b/ddmrp_report_part_flow_index/reports/report_ddmrp_part_plan_flow_index.py
@@ -67,12 +67,17 @@ class ReportDdmrpPartsPlanFlowIndex(models.Model):
         """
         return select_str
 
+    @api.model
+    def _sub_where(self):
+        return "WHERE active IS TRUE"
+
     @property
     def _table_query(self):
         return """
                 WITH a AS
                     (SELECT %s
-                     FROM stock_buffer)
+                     FROM stock_buffer
+                     %s)
                 SELECT
                     %s
                 FROM a
@@ -84,6 +89,7 @@ class ReportDdmrpPartsPlanFlowIndex(models.Model):
                 ON a.order_frequency_group = b.order_frequency_group
             """ % (
             self._sub_select(),
+            self._sub_where(),
             self._select(),
             self._join_select(),
         )

--- a/ddmrp_report_part_flow_index/reports/report_ddmrp_part_plan_flow_index_views.xml
+++ b/ddmrp_report_part_flow_index/reports/report_ddmrp_part_plan_flow_index_views.xml
@@ -29,7 +29,7 @@
         <field name="model">report.ddmrp.part.plan.flow.index</field>
         <field name="arch" type="xml">
             <tree name="Parts Plan Flow Index">
-                <field name="buffer_id" />
+                <field name="buffer_id" widget="many2one" />
                 <field name="product_id" />
                 <field name="location_id" />
                 <field name="green_zone_qty" />

--- a/ddmrp_report_part_flow_index/tests/__init__.py
+++ b/ddmrp_report_part_flow_index/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_ddmrp_report_part_flow_index

--- a/ddmrp_report_part_flow_index/tests/test_ddmrp_report_part_flow_index.py
+++ b/ddmrp_report_part_flow_index/tests/test_ddmrp_report_part_flow_index.py
@@ -1,0 +1,67 @@
+# Copyright 2025 ForgeFlow S.L. (https://www.forgeflow.com)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo.tests import TransactionCase
+
+
+class TestDDMRPReportPartFlowIndex(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.buffer_profile_mmm = self.env.ref(
+            "ddmrp.stock_buffer_profile_replenish_manufactured_medium_medium"
+        )
+        self.stock_location = self.env.ref("stock.stock_location_stock")
+        self.warehouse = self.env.ref("stock.warehouse0")
+        self.adu_fixed = self.env.ref("ddmrp.adu_calculation_method_fixed")
+        self.product = self.env["product.product"].create(
+            {
+                "name": "product test",
+                "type": "product",
+            }
+        )
+        self.buffer = self.env["stock.buffer"].create(
+            {
+                "buffer_profile_id": self.buffer_profile_mmm.id,
+                "product_id": self.product.id,
+                "location_id": self.stock_location.id,
+                "warehouse_id": self.warehouse.id,
+                "adu_calculation_method": self.adu_fixed.id,
+                "adu_fixed": 4.0,
+                "order_cycle": 5,
+            }
+        )
+        self.flow_index_group_1 = self.env["ddmrp.flow.index.group"].create(
+            {"name": "Group 1", "lower_range": 1, "upper_range": 10, "sequence": 0}
+        )
+        self.flow_index_group_2 = self.env["ddmrp.flow.index.group"].create(
+            {"name": "Group 2", "lower_range": 11, "upper_range": 30, "sequence": 1}
+        )
+        self.env.flush_all()
+
+    def test_01_calc_flow_index_group_id(self):
+        """Check if the flow_index_group_id of one buffer is correctly calculated"""
+
+        self.buffer.cron_actions()
+        self.assertEqual(
+            self.buffer.flow_index_group_id,
+            self.flow_index_group_1,
+            "Flow index group was not updated correctly!",
+        )
+        self.buffer.order_cycle = 20
+        self.env.invalidate_all()
+        # Command needed to update report
+        self.buffer.cron_actions()
+        self.assertEqual(
+            self.buffer.flow_index_group_id,
+            self.flow_index_group_2,
+            "Flow index group was not updated correctly!",
+        )
+
+    def test_02_archived_buffers_excluded(self):
+        """Archived buffers must not appear in the report"""
+        self.buffer.cron_actions()
+        report = self.env["report.ddmrp.part.plan.flow.index"]
+        self.assertTrue(report.search([("buffer_id", "=", self.buffer.id)]))
+        self.buffer.toggle_active()
+        self.env.invalidate_all()
+        self.assertFalse(report.search([("buffer_id", "=", self.buffer.id)]))


### PR DESCRIPTION
Also, take the ocassion to make buffer_id clickable in tree view.

Backport https://github.com/OCA/ddmrp/pull/608