### PR TITLE
[19.0][FIX] ddmrp: aggregate future actual demand in product UoM

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -1550,7 +1550,7 @@ class StockBuffer(models.Model):
         elif self.adu_calculation_method.source_future == "actual":
             domain = self._future_moves_domain(date_from, date_to, locations)
             for [total] in self.env["stock.move"]._read_group(
-                domain, aggregates=["product_uom_qty:sum"]
+                domain, aggregates=["product_qty:sum"]
             ):
                 qty += total or 0.0
         return qty / horizon

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -1533,3 +1533,26 @@ class TestDdmrp(TestDdmrpCommon):
         data = json.loads(form.ddmrp_chart_execution)
         self.assertEqual(data["div"], "")
         self.assertEqual(data["script"], "")
+
+    def test_51_adu_calculation_future_actual_move_uom(self):
+        """Future actual demand is aggregated in the product UoM.
+
+        A move expressed in a secondary UoM (Dozen) must contribute its
+        product-UoM quantity to the ADU, not its move-UoM quantity.
+        """
+        method = self.aducalcmethodModel.create(
+            {
+                "name": "Future actual demand (120 days)",
+                "method": "future",
+                "source_future": "actual",
+                "horizon_future": 120,
+                "company_id": self.main_company.id,
+            }
+        )
+        self.buffer_a.adu_calculation_method = method.id
+        days = 30
+        date_move = self.calendar.plan_days(+1 * days + 1, datetime.today())
+        self.create_pickingoutA(date_move, 5, uom=self.dozen_unit)
+        self.bufferModel.cron_ddmrp_adu()
+        # 5 Dozen = 60 Units over the 120-day horizon
+        self.assertEqual(self.buffer_a.adu, 60 / 120)


### PR DESCRIPTION
`_calc_adu_future_demand` sums `product_uom_qty:sum` — the move-UoM "Demand" field — so a future delivery of 5 Dozen contributes 5 instead of 60 to the ADU, undersizing buffers for any secondary-UoM demand.

18.0 summed `product_qty` (product UoM, still stored/groupable in 19.0), as this method has since the 13.0 refactor; every other quantity ddmrp aggregates is product-UoM-normalized (past ADU via `quantity_product_uom`, qualified demand, incoming).

The regression test alone against unmodified 19.0 fails ([run](https://github.com/ledoent/ddmrp/actions/runs/27344118311/job/80788172608), 1 failed of 61):

```
FAIL: TestDdmrp.test_51_adu_calculation_future_actual_move_uom
AssertionError: 0.042 != 0.5
```

With the one-line fix it passes ([run](https://github.com/ledoent/ddmrp/actions/runs/27344116959/job/80788167832)).
