### PR TITLE
[19.0][FIX] ddmrp: NewId-safe buffer-link lookup on purchase lines

### DIFF
--- a/ddmrp/models/purchase_order.py
+++ b/ddmrp/models/purchase_order.py
@@ -81,7 +81,7 @@ class PurchaseOrderLine(models.Model):
         move_model = self.env["stock.move"]
         for rec in self.filtered(lambda r: not r.buffer_ids):
             mto_move = move_model.search(
-                [("created_purchase_line_ids", "in", rec.id)], limit=1
+                [("created_purchase_line_ids", "in", rec.ids)], limit=1
             )
             if mto_move:
                 # MTO lines are not accounted in MTS stock buffers.

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -1556,3 +1556,13 @@ class TestDdmrp(TestDdmrpCommon):
         self.bufferModel.cron_ddmrp_adu()
         # 5 Dozen = 60 Units over the 120-day horizon
         self.assertEqual(self.buffer_a.adu, 60 / 120)
+
+    def test_55_purchase_line_form_no_newid_domain_warning(self):
+        """Editing a PO line in the UI must not search with NewId records."""
+        vendor = self.partner_model.create({"name": "Form Vendor"})
+        po_form = Form(self.env["purchase.order"])
+        po_form.partner_id = vendor
+        with self.assertNoLogs("odoo.domains", level="WARNING"):
+            with po_form.order_line.new() as line:
+                line.product_id = self.product_purchased
+        po_form.save()


### PR DESCRIPTION
One-character fix (`rec.id` → `rec.ids`) in `_find_buffer_link`'s move search, plus a regression test.

The method is reachable on unpersisted (NewId) lines — via the `_product_id_change` onchange helper and 19.0's form-view validation — and searching with `rec.id` logs `Domains don't support NewId`, which fails OCA checklog for any dependent module that loads a purchase view or creates an order in tests. `rec.ids` is empty for NewId records, keeping the lookup a no-op there (same effective behavior as before).

The test drives a purchase line through `Form` under `assertNoLogs("odoo.domains")` — it fails on the unmodified branch.
