### PR TITLE
[19.0][FIX] ddmrp: pin test_04 ADU-window test to a fixed weekday

### DIFF
--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -5,6 +5,8 @@
 import json
 from datetime import datetime, time, timedelta
 
+from freezegun import freeze_time
+
 from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import Form
@@ -95,6 +97,7 @@ class TestDdmrp(TestDdmrpCommon):
         to_assert_value = (20 + 20 + 10) / 6
         self.assertAlmostEqual(self.buffer_a.adu, to_assert_value, places=2)
 
+    @freeze_time("2020-12-10 10:00:00")
     def test_04_adu_calculation_window_past_calendar(self):
         """Test that the window considered to calculate the ADU is correct.
         (With working days set)."""


### PR DESCRIPTION
Makes `test_04_adu_calculation_window_past_calendar` deterministic regardless of which weekday CI runs on.

The test anchors its demand moves on `datetime.today()` through `resource.calendar.plan_days()` (working-day-aware). On weekend runs the working-day window shifts by a day, so one in-window move drops out and the ADU assertion fails (`6.667 != 8.333`). `_calc_adu` also reads the real current date, so freezing the test data alone is not enough — the whole method is pinned with `freeze_time` (already a `ddmrp` test dependency, cf. `test_distributed_max_proc_time.py`).

Not visible on the current `19.0` branch because its last CI run landed on a weekday; it surfaces on Saturday/Sunday runs.


Evidence from a Sunday CI run: [failing on the unmodified branch](https://github.com/ledoent/ddmrp/actions/runs/27092429455/job/79958330677) (`FAIL: test_04 ... AssertionError: 6.667 != 8.333`) vs [green with the fix, same day](https://github.com/ledoent/ddmrp/actions/runs/27095225243/job/79966030582).
