### PR TITLE
[19.0][UPD] copier template to v1.43

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,8 +1,7 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.35
+_commit: v1.43
 _src_path: git+https://github.com/OCA/oca-addons-repo-template
 additional_ruff_rules: []
-ci: GitHub
 convert_readme_fragments_to_markdown: true
 enable_checklog_odoo: true
 generate_requirements_txt: true
@@ -17,6 +16,7 @@ odoo_test_flavor: Both
 odoo_version: 19.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
+postgres_image: ''
 rebel_module_groups: []
 repo_description: ddmrp
 repo_name: ddmrp

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,3 +1,4 @@
+
 name: pre-commit
 
 on:
@@ -16,7 +17,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
+          cache: 'pip'
+          cache-dependency-path: '.pre-commit-config.yaml'
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
       - uses: actions/cache@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,13 @@ jobs:
         run: oca_init_test_database
       - name: Run tests
         run: oca_run_tests
+      - name: Upload screenshots from JS tests
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: Screenshots of failed JS tests - ${{ matrix.name }}${{ join(matrix.include) }}
+          path: /tmp/odoo_tests/${{ env.PGDATABASE }}
+          if-no-files-found: ignore
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ exclude: |
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
-  python: python3
+  python: python3.12
   node: "22.9.0"
 repos:
   - repo: local
@@ -38,6 +38,11 @@ repos:
         entry: found a en.po file
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
+      - id: obsolete dotfiles
+        name: obsolete dotfiles
+        entry: found obsolete files; remove them
+        files: '^(\.travis\.yml|\.t2d\.yml|CONTRIBUTING\.md|\.prettierrc\.yml|\.eslintrc\.yml)$'
+        language: fail
   - repo: https://github.com/sbidoul/whool
     rev: v1.3
     hooks:
@@ -60,7 +65,7 @@ repos:
           - --convert-fragments-to-markdown
       - id: oca-gen-external-dependencies
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
-    rev: v0.1.6
+    rev: v0.1.7
     hooks:
       - id: oca-checks-odoo-module
       - id: oca-checks-po

--- a/.pylintrc
+++ b/.pylintrc
@@ -92,20 +92,11 @@ enable=anomalous-backslash-in-string,
     no-write-in-compute,
     # messages that do not cause the lint step to fail
     consider-merging-classes-inherited,
-    create-user-wo-reset-password,
-    dangerous-filter-wo-user,
     deprecated-module,
-    file-not-used,
     invalid-commit,
-    missing-manifest-dependency,
-    missing-newline-extrafiles,
     missing-readme,
-    no-utf8-coding-comment,
     odoo-addons-relative-import,
-    old-api7-method-defined,
     redefined-builtin,
-    too-complex,
-    unnecessary-utf8-coding-comment,
     manifest-external-assets
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 
+[![Support the OCA](https://odoo-community.org/readme-banner-image)](https://odoo-community.org/get-involved?utm_source=repo-readme)
+
+# ddmrp
 [![Runboat](https://img.shields.io/badge/runboat-Try%20me-875A7B.png)](https://runboat.odoo-community.org/builds?repo=OCA/ddmrp&target_branch=19.0)
 [![Pre-commit Status](https://github.com/OCA/ddmrp/actions/workflows/pre-commit.yml/badge.svg?branch=19.0)](https://github.com/OCA/ddmrp/actions/workflows/pre-commit.yml?query=branch%3A19.0)
 [![Build Status](https://github.com/OCA/ddmrp/actions/workflows/test.yml/badge.svg?branch=19.0)](https://github.com/OCA/ddmrp/actions/workflows/test.yml?query=branch%3A19.0)
@@ -6,8 +9,6 @@
 [![Translation Status](https://translation.odoo-community.org/widgets/ddmrp-19-0/-/svg-badge.svg)](https://translation.odoo-community.org/engage/ddmrp-19-0/?utm_source=widget)
 
 <!-- /!\ do not modify above this line -->
-
-# ddmrp
 
 ddmrp
 

--- a/checklog-odoo.cfg
+++ b/checklog-odoo.cfg
@@ -1,3 +1,5 @@
 [checklog-odoo]
 ignore=
     WARNING.* 0 failed, 0 error\(s\).*
+    WARNING .* Killing chrome descendants-or-self .*
+    WARNING.* Missing widget: res_partner_many2one for field of type many2one.*


### PR DESCRIPTION
`copier update` to bring the repo template from **v1.35 → v1.43** (latest).

Routine maintenance — dotfiles / CI workflows only, **no addon code changes**:
- CI: Python 3.11 → 3.12, pip caching, JS-test screenshot artifact upload.
- `.pylintrc`: drop obsolete (now unknown) message names.
- README banner + `checklog-odoo.cfg` ignore patterns.

Brings 19.0 in line with the current OCA repo template (16.0 was updated to v1.39 in #582). `pre-commit run --all-files` is clean — no regeneration/reformat fallout.
