### PR TITLE
[17.0][FIX] ddmrp: guard stock.buffer references in shared views

### DIFF
--- a/ddmrp/views/product_view.xml
+++ b/ddmrp/views/product_view.xml
@@ -16,6 +16,7 @@
                     class="oe_stat_button"
                     icon="fa-flask"
                     invisible="buffer_count == 0"
+                    groups="stock.group_stock_user"
                 >
                     <field
                         name="buffer_count"
@@ -42,6 +43,7 @@
                     class="oe_stat_button"
                     icon="fa-flask"
                     invisible="buffer_count == 0"
+                    groups="stock.group_stock_user"
                 >
                     <field
                         name="buffer_count"

--- a/ddmrp/views/purchase_order_line_view.xml
+++ b/ddmrp/views/purchase_order_line_view.xml
@@ -45,6 +45,7 @@
                     name="hide_no_buffer"
                     string="Buffered"
                     domain="[('buffer_ids','!=',False), ('execution_priority_level','!=',False)]"
+                    groups="stock.group_stock_user"
                 />
                 <separator />
                 <group name="execution_priority" string="On Hand Alert Zones">
@@ -79,6 +80,7 @@
         id="menu_pol_execution"
         action="po_line_execution_action"
         parent="purchase.menu_procurement_management"
+        groups="stock.group_stock_user"
         sequence="8"
     />
 </odoo>

--- a/ddmrp/views/purchase_order_view.xml
+++ b/ddmrp/views/purchase_order_view.xml
@@ -11,12 +11,17 @@
                 expr="//field[@name='order_line']//field[@name='date_planned']"
                 position="after"
             >
-                <field name="buffer_ids" column_invisible="1" />
+                <field
+                    name="buffer_ids"
+                    column_invisible="1"
+                    groups="stock.group_stock_user"
+                />
                 <field name="execution_priority_level" column_invisible="1" />
                 <field
                     name="on_hand_percent"
                     options='{"buffer_id": "buffer_ids", "color_from": "execution_priority_level", "field": "ddmrp_chart_execution"}'
                     widget="stock_buffer_info"
+                    groups="stock.group_stock_user"
                 />
             </xpath>
             <xpath
@@ -62,8 +67,10 @@
         <field name="inherit_id" ref="purchase.purchase_order_line_form2" />
         <field name="arch" type="xml">
             <field name="name" position="after">
-                <separator string="Stock Buffers" />
-                <field name="buffer_ids" />
+                <t groups="stock.group_stock_user">
+                    <separator string="Stock Buffers" />
+                    <field name="buffer_ids" />
+                </t>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Fields and buttons referencing stock.buffer were injected into views of models that can be opened without stock.group_stock_user (product, purchase). Reading the related buffer records raised an AccessError for users without that group. Restrict those elements with groups="stock.group_stock_user".

BP of https://github.com/OCA/ddmrp/pull/622