### PR TITLE
[18.0][FIX] ddmrp: show all demand moves in demand chart

### DIFF
--- a/ddmrp/models/stock_buffer.py
+++ b/ddmrp/models/stock_buffer.py
@@ -823,7 +823,7 @@ class StockBuffer(models.Model):
                 continue
 
             # Prepare data:
-            demand_data = rec._get_demand_by_days(rec.qualified_demand_stock_move_ids)
+            demand_data = rec._get_demand_by_days(rec.demand_stock_move_ids)
             mrp_data = rec._get_qualified_mrp_moves(rec.qualified_demand_mrp_move_ids)
             supply_data = rec._get_incoming_by_days()
             width = timedelta(days=0.4)

--- a/ddmrp/tests/test_ddmrp.py
+++ b/ddmrp/tests/test_ddmrp.py
@@ -2,6 +2,7 @@
 # Copyright 2016 Aleph Objects, Inc. (https://www.alephobjects.com/)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
+import json
 from datetime import datetime, time, timedelta
 
 from odoo import fields
@@ -1528,3 +1529,24 @@ class TestDdmrp(TestDdmrpCommon):
             action["context"].get("search_default_qualified_demand_buffer_ids"),
             self.buffer_a.name,
         )
+
+    def test_50_demand_chart_shows_all_demand_moves(self):
+        """The demand chart must plot every demand move (demand_stock_move_ids),
+        not only the ones that qualify as qualified demand. A move within the
+        order spike horizon but below the threshold is demand yet never
+        qualifies, so it must still show up in the chart."""
+        threshold = self.buffer_a.order_spike_threshold
+        date_within_horizon = datetime.today() + timedelta(
+            days=self.buffer_a.order_spike_horizon - 1
+        )
+        self.create_pickingoutA(date_within_horizon, threshold - 1)
+        self.buffer_a.cron_actions()
+        # The move is demand but does not qualify as qualified demand.
+        self.assertTrue(self.buffer_a.demand_stock_move_ids)
+        self.assertFalse(self.buffer_a.qualified_demand_stock_move_ids)
+        self.assertEqual(self.buffer_a.qualified_demand, 0.0)
+        # If the chart were built from qualified_demand_stock_move_ids (the
+        # regression), there would be no demand data to plot at all.
+        chart_data = json.loads(self.buffer_a.ddmrp_demand_chart)
+        self.assertNotIn("No demand detected", chart_data["div"])
+        self.assertTrue(chart_data["script"])


### PR DESCRIPTION
Added a regression test.

<img width="594" height="543" alt="image" src="https://github.com/user-attachments/assets/4cf7e10c-8b14-4157-a75d-e9383c07886d" />
